### PR TITLE
Discovery Scheduler Configuration: persistence, service, and REST endpoint

### DIFF
--- a/.claude/context/csdk-context.md
+++ b/.claude/context/csdk-context.md
@@ -7,7 +7,7 @@
 ## Stack
 
 - **Java 25 · Spring Boot 4.0.5 · Gradle 9** — base package `uk.gov.hmcts.cp.cdk`, port 8082, context path `/casedocumentknowledge-service`
-- **PostgreSQL 16** + **Flyway** (migrations `V1000–V1010`, append-only)
+- **PostgreSQL 16** + **Flyway** (migrations `V1000–V1011`, append-only)
 - **Azure Blob Storage** (`azure-storage-blob` 12.32.0) — authenticated via **Managed Identity only** (`AzureIdentityConfig` → `AzureTokenService` → `ApimAuthHeaderService`)
 - **ActiveMQ Artemis 2.31.2** — audit event publishing only (via `cp-audit-filter-springboot`); no `@JmsListener` in service code
 - **ShedLock** (JDBC, `V1010`) — guards `IntradayDiscoveryScheduler`
@@ -18,10 +18,10 @@
 
 | Package | Purpose |
 |---------|---------|
-| `controllers/` | REST API: `Answers`, `Document`, `Ingestion`, `Queries`, `QueryCatalogue` + `GlobalExceptionHandler` |
-| `services/` | Business logic: answer generation, query management, document discovery, ingestion orchestration |
-| `domain/` | 22 JPA entities: `Query`, `QueryVersion`, `CaseDocument`, `CaseQueryStatus`, answer variants, `DocumentVerificationTask`, `ScheduledIngestionRequest` |
-| `repo/` | 13 JPA repositories |
+| `controllers/` | REST API: `Answers`, `Document`, `Ingestion`, `Queries`, `QueryCatalogue`, `DiscoveryScheduler` + `GlobalExceptionHandler` |
+| `services/` | Business logic: answer generation, query management, document discovery, ingestion orchestration, discovery scheduler configuration |
+| `domain/` | 23 JPA entities: `Query`, `QueryVersion`, `CaseDocument`, `CaseQueryStatus`, answer variants, `DocumentVerificationTask`, `ScheduledIngestionRequest`, `DiscoverySchedulerConfiguration` |
+| `repo/` | 14 JPA repositories |
 | `jobmanager/` | Long-running task orchestration via Task Manager service: `caseflow/` (5 multi-defendant tasks), `queryflow/`, `hearing/` |
 | `scheduler/` | `IntradayDiscoveryScheduler` — every 10 min, Mon–Fri 07:00–19:50, ShedLock-guarded |
 | `clients/` | External integrations: `rag/` (AI), `hearing/`, `progression/`, `common/` (Azure auth + APIM) |
@@ -58,13 +58,15 @@ All APIM calls: `RestClientFactoryConfig` → `CorrelationIdInterceptor` → `Ap
 | `/queries` | POST |
 | `/query-catalogue`, `/query-catalogue/{queryId}` | GET |
 | `/query-catalogue/{queryId}/label` | PATCH |
+| `/discovery-scheduler/configurations` | POST |
 
 ---
 
 ## Access control
 
 - Framework: `cp-auth-rules-filter` (Drools, `acl/cdks-rules.drl`)
-- All endpoints require `"AI search"` permission or System Users group
+- Most endpoints require `"AI search"` permission or System Users group
+- Exception: `/discovery-scheduler/configurations` (action `casedocumentknowledge-service.discovery-scheduler-configuration`) is **System Users group only** — no `"AI search"` fallback, since it's a backend config write, not an end-user action
 - User context header: `CJSCPPUID`
 - Permission constant: `PermissionConstants.INTELLIGENCE_ACCESS`
 
@@ -86,7 +88,7 @@ All APIM calls: `RestClientFactoryConfig` → `CorrelationIdInterceptor` → `Ap
 
 1. **No PII / case content in logs, tests, or artefacts** — use synthetic data; Azurite seed and WireMock stubs must be non-real.
 2. **Azure via Managed Identity only** — no connection strings, SAS tokens, or account keys anywhere.
-3. **Flyway migrations are append-only** — never edit a shipped `V*.sql`; add the next version. Current highest: `V1010`; next is `V1011`.
+3. **Flyway migrations are append-only** — never edit a shipped `V*.sql`; add the next version. Current highest: `V1011`; next is `V1012`.
 4. **Do not drop RAG response fields** — changes to the ingestion or answer-serving flow must preserve all fields returned by the RAG service (e.g. `doc_id`, `llm_input`). Citation production is upstream's responsibility; CSDK's responsibility is not to lose that data.
 5. **JSON logging to stdout only** — `logback-spring.xml`; never log document content, answer text, or CJSCPPUID values.
 6. **PMD + JaCoCo must pass** — do not lower thresholds.

--- a/.claude/context/tech-stack.md
+++ b/.claude/context/tech-stack.md
@@ -28,7 +28,7 @@
 |-----------|-----------------|
 | PostgreSQL | 16 (production), 16-alpine (Docker Compose) |
 | Flyway | 7.x — migrations in `src/main/resources/db/migration/` |
-| Migration prefix | `V1000` – `V1010` (append-only; never edit shipped versions) |
+| Migration prefix | `V1000` – `V1011` (append-only; never edit shipped versions) |
 | HikariCP | max 20 connections, min 5, 300 s timeout |
 | JPA DDL | `validate` — Flyway owns schema; Hibernate must not auto-create |
 | Timezone | UTC enforced via JPA/JDBC properties |
@@ -47,6 +47,7 @@
 | `V1008__alter_document_ingestion_phase_enum_file_size_limit.sql` | Ingestion phase enum + file size tracking |
 | `V1009__case_documents_scheduled_ingestion_request.sql` | `scheduled_ingestion_request` table |
 | `V1010__create_shedlock_table.sql` | `shedlock` table for distributed scheduler lock |
+| `V1011__create_discovery_scheduler_configuration.sql` | `discovery_scheduler_configuration` table (versioned court centre/court room ingestion config) |
 
 ---
 
@@ -96,7 +97,7 @@ All APIM calls carry a subscription key or AAD token injected by `ApimAuthHeader
 
 | Dependency | Version | Purpose |
 |-----------|---------|---------|
-| `api-cp-crime-caseadmin-case-document-knowledge` | 0.0.9 | OpenAPI models for CSDK own API |
+| `api-cp-crime-caseadmin-case-document-knowledge` | 0.0.10 | OpenAPI models for CSDK own API |
 | `api-cp-ai-rag` | 0.0.12 | RAG service API models |
 | `cp-auth-rules-filter` | 1.0.7 | Drools-based HTTP authorization |
 | `cp-audit-filter-springboot` | 1.0.5 | Audit event filter (publishes to Artemis) |
@@ -180,7 +181,8 @@ Integration test compose stack:
 - Permission constant: `"AI search"` (`PermissionConstants.INTELLIGENCE_ACCESS`)
 - Excluded from auth: `/usersgroups-query-api/`, `/actuator`, `/error`
 
-All endpoints require `"AI search"` permission or System Users group membership.
+Most endpoints require `"AI search"` permission or System Users group membership.
+Exception: `/discovery-scheduler/configurations` (action `casedocumentknowledge-service.discovery-scheduler-configuration`) is **System Users group only** — no `"AI search"` fallback, since it's a backend config write, not an end-user action.
 
 ---
 
@@ -212,6 +214,7 @@ Integration testing adds: `artemis`, `azurite`, `azurite-seed`, `wiremock`.
 | `/query-catalogue` | GET | Browse query catalogue |
 | `/query-catalogue/{queryId}` | GET | Single catalogue entry |
 | `/query-catalogue/{queryId}/label` | PATCH | Update label/order |
+| `/discovery-scheduler/configurations` | POST | Upsert versioned court centre/court room ingestion config |
 
 ---
 
@@ -219,10 +222,10 @@ Integration testing adds: `artemis`, `azurite`, `azurite-seed`, `wiremock`.
 
 ```
 uk.gov.hmcts.cp.cdk
-├── controllers/          REST controllers + exception handler + accesscontrol/
-├── services/             Business logic (Answer, Query, Document, Discovery, Ingestion)
-├── domain/               JPA entities (22 classes) + enums
-├── repo/                 JPA repositories (13) + helpers
+├── controllers/          REST controllers (incl. DiscoverySchedulerController) + exception handler + accesscontrol/
+├── services/             Business logic (Answer, Query, Document, Discovery, Ingestion, DiscoverySchedulerConfiguration)
+├── domain/               JPA entities (23 classes) + enums
+├── repo/                 JPA repositories (14) + helpers
 ├── jobmanager/           Task orchestration: caseflow/, queryflow/, hearing/, support/
 ├── scheduler/            IntradayDiscoveryScheduler + SchedulerProperties
 ├── clients/              External clients: rag/, hearing/, progression/, common/, config/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 JAVA_VERSION=25
-version.cdk=0.0.9
+version.cdk=0.0.10
 version.aiRag=0.0.12
 version.apiSpec=0.4.2
 version.lombok=1.18.42

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerConfigurationHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerConfigurationHttpLiveTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cp.cdk.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 import uk.gov.hmcts.cp.cdk.util.UtilConstants;
@@ -78,10 +79,14 @@ class DiscoverySchedulerConfigurationHttpLiveTest extends AbstractHttpLiveTest {
             ps.setObject(1, courtCentreId);
             ps.setObject(2, courtRoomId);
             try (ResultSet rs = ps.executeQuery()) {
-                assertThat(rs.next()).isTrue();
+                if (!rs.next()) {
+                    fail("Expected latest discovery scheduler configuration row to exist");
+                }
                 assertThat(rs.getInt("version")).isEqualTo(2);
                 assertThat(rs.getBoolean("is_active")).isFalse();
-                assertThat(rs.next()).isFalse();
+                if (rs.next()) {
+                    fail("Expected only one row for this court centre/court room pair");
+                }
             }
         }
     }
@@ -97,7 +102,7 @@ class DiscoverySchedulerConfigurationHttpLiveTest extends AbstractHttpLiveTest {
 
         try {
             postConfiguration(courtCentreId, courtRoomId, 1, true);
-            org.junit.jupiter.api.Assertions.fail("Expected duplicate version to be rejected");
+            fail("Expected duplicate version to be rejected");
         } catch (final org.springframework.web.client.HttpClientErrorException ex) {
             assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
         }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerConfigurationHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerConfigurationHttpLiveTest.java
@@ -1,0 +1,105 @@
+package uk.gov.hmcts.cp.cdk.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
+import uk.gov.hmcts.cp.cdk.util.UtilConstants;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * End-to-end tests for:
+ * - POST /discovery-scheduler/configurations
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiscoverySchedulerConfigurationHttpLiveTest extends AbstractHttpLiveTest {
+
+    private static final MediaType VND_TYPE_JSON = MediaType.valueOf(
+            "application/vnd.casedocumentknowledge-service.discovery-scheduler-configuration+json");
+
+    private ResponseEntity<String> postConfiguration(final UUID courtCentreId, final UUID courtRoomId,
+                                                       final int version, final boolean isActive) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(VND_TYPE_JSON);
+        headers.setAccept(List.of(VND_TYPE_JSON));
+        headers.set(UtilConstants.CJSCPPUID, UtilConstants.USER_WITH_SYSTEM_USERS_GROUPS);
+
+        final String body = """
+                {
+                  "courtCentreId": "%s",
+                  "courtRoomId": "%s",
+                  "uploadedDate": "2026-06-16",
+                  "version": %d,
+                  "isActive": %b
+                }
+                """.formatted(courtCentreId, courtRoomId, version, isActive);
+
+        return http.exchange(
+                baseUrl + "/discovery-scheduler/configurations",
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                String.class
+        );
+    }
+
+    @Test
+    @DisplayName("POST configurations persists multiple versions and latest version reflects the newest upload")
+    void postConfigurations_persistsMultipleVersions_andLatestReflectsNewest() throws SQLException {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final ResponseEntity<String> v1Response = postConfiguration(courtCentreId, courtRoomId, 1, true);
+        assertThat(v1Response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(v1Response.getBody()).contains("message");
+
+        final ResponseEntity<String> v2Response = postConfiguration(courtCentreId, courtRoomId, 2, false);
+        assertThat(v2Response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        try (Connection connection = openConnection();
+             PreparedStatement ps = connection.prepareStatement(
+                     "SELECT version, is_active FROM discovery_scheduler_configuration "
+                             + "WHERE court_centre_id = ? AND court_room_id = ? "
+                             + "ORDER BY version DESC LIMIT 1")) {
+            ps.setObject(1, courtCentreId);
+            ps.setObject(2, courtRoomId);
+            try (ResultSet rs = ps.executeQuery()) {
+                assertThat(rs.next()).isTrue();
+                assertThat(rs.getInt("version")).isEqualTo(2);
+                assertThat(rs.getBoolean("is_active")).isFalse();
+                assertThat(rs.next()).isFalse();
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("POST configurations rejects duplicate courtCentre/courtRoom/version with 409")
+    void postConfigurations_rejectsDuplicateVersion() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final ResponseEntity<String> firstResponse = postConfiguration(courtCentreId, courtRoomId, 1, true);
+        assertThat(firstResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        try {
+            postConfiguration(courtCentreId, courtRoomId, 1, true);
+            org.junit.jupiter.api.Assertions.fail("Expected duplicate version to be rejected");
+        } catch (final org.springframework.web.client.HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
@@ -22,7 +22,10 @@ public class DiscoverySchedulerController implements DiscoverySchedulerApi {
     @Override
     public ResponseEntity<UpsertDiscoverySchedulerConfiguration200Response> upsertDiscoverySchedulerConfiguration(
             @RequestBody @Valid final DiscoverySchedulerConfigurationRequest discoverySchedulerConfigurationRequest) {
-        log.debug("upsertDiscoverySchedulerConfiguration request={}", discoverySchedulerConfigurationRequest);
+        log.debug("upsertDiscoverySchedulerConfiguration courtCentreId={} courtRoomId={} version={}",
+                discoverySchedulerConfigurationRequest.getCourtCentreId(),
+                discoverySchedulerConfigurationRequest.getCourtRoomId(),
+                discoverySchedulerConfigurationRequest.getVersion());
         return ResponseEntity.ok(service.upsert(discoverySchedulerConfigurationRequest));
     }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.cp.cdk.controllers;
+
+import uk.gov.hmcts.cp.cdk.services.DiscoverySchedulerConfigurationService;
+import uk.gov.hmcts.cp.openapi.api.cdk.DiscoverySchedulerApi;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class DiscoverySchedulerController implements DiscoverySchedulerApi {
+
+    private final DiscoverySchedulerConfigurationService service;
+
+    @Override
+    public ResponseEntity<UpsertDiscoverySchedulerConfiguration200Response> upsertDiscoverySchedulerConfiguration(
+            @RequestBody @Valid final DiscoverySchedulerConfigurationRequest discoverySchedulerConfigurationRequest) {
+        log.debug("upsertDiscoverySchedulerConfiguration request={}", discoverySchedulerConfigurationRequest);
+        return ResponseEntity.ok(service.upsert(discoverySchedulerConfigurationRequest));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/domain/DiscoverySchedulerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/domain/DiscoverySchedulerConfiguration.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.cp.cdk.domain;
+
+import static uk.gov.hmcts.cp.cdk.util.TimeUtils.utcNow;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@EqualsAndHashCode
+@Entity
+@Table(
+        name = "discovery_scheduler_configuration",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uq_dsc_centre_room_version",
+                        columnNames = {
+                                "court_centre_id",
+                                "court_room_id",
+                                "version"
+                        }
+                )
+        },
+        indexes = {
+                @Index(
+                        name = "idx_dsc_centre_room",
+                        columnList = "court_centre_id, court_room_id"
+                )
+        }
+)
+public class DiscoverySchedulerConfiguration {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @Column(name = "court_centre_id", nullable = false)
+    private UUID courtCentreId;
+
+    @Column(name = "court_room_id", nullable = false)
+    private UUID courtRoomId;
+
+    @Column(name = "uploaded_date", nullable = false)
+    private LocalDate uploadedDate;
+
+    @Column(name = "version", nullable = false)
+    private Integer version;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt = utcNow();
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt = utcNow();
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepository.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepository.java
@@ -1,0 +1,23 @@
+package uk.gov.hmcts.cp.cdk.repo;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DiscoverySchedulerConfigurationRepository extends JpaRepository<DiscoverySchedulerConfiguration, UUID> {
+
+    @Query(value = "SELECT * FROM discovery_scheduler_configuration "
+            + "WHERE court_centre_id = :courtCentreId AND court_room_id = :courtRoomId "
+            + "ORDER BY version DESC LIMIT 1", nativeQuery = true)
+    Optional<DiscoverySchedulerConfiguration> findLatestByCourtCentreAndCourtRoom(
+            @Param("courtCentreId") UUID courtCentreId, @Param("courtRoomId") UUID courtRoomId);
+
+    boolean existsByCourtCentreIdAndCourtRoomIdAndVersion(UUID courtCentreId, UUID courtRoomId, Integer version);
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepository.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepository.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cp.cdk.repo;
 
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -18,6 +19,12 @@ public interface DiscoverySchedulerConfigurationRepository extends JpaRepository
             + "ORDER BY version DESC LIMIT 1", nativeQuery = true)
     Optional<DiscoverySchedulerConfiguration> findLatestByCourtCentreAndCourtRoom(
             @Param("courtCentreId") UUID courtCentreId, @Param("courtRoomId") UUID courtRoomId);
+
+    @Query(value = "SELECT DISTINCT ON (court_centre_id, court_room_id) * "
+            + "FROM discovery_scheduler_configuration "
+            + "WHERE is_active = true "
+            + "ORDER BY court_centre_id, court_room_id, version DESC", nativeQuery = true)
+    List<DiscoverySchedulerConfiguration> findLatestActiveConfigurations();
 
     boolean existsByCourtCentreIdAndCourtRoomIdAndVersion(UUID courtCentreId, UUID courtRoomId, Integer version);
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoverySchedulerConfigurationService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoverySchedulerConfigurationService.java
@@ -1,0 +1,45 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
+import uk.gov.hmcts.cp.cdk.services.mapper.DiscoverySchedulerConfigurationMapper;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+public class DiscoverySchedulerConfigurationService {
+
+    private final DiscoverySchedulerConfigurationRepository repository;
+    private final DiscoverySchedulerConfigurationMapper mapper;
+
+    public DiscoverySchedulerConfigurationService(final DiscoverySchedulerConfigurationRepository repository,
+                                                   final DiscoverySchedulerConfigurationMapper mapper) {
+        this.repository = repository;
+        this.mapper = mapper;
+    }
+
+    @Transactional
+    public UpsertDiscoverySchedulerConfiguration200Response upsert(final DiscoverySchedulerConfigurationRequest request) {
+        if (repository.existsByCourtCentreIdAndCourtRoomIdAndVersion(
+                request.getCourtCentreId(), request.getCourtRoomId(), request.getVersion())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Discovery scheduler configuration already exists for this court centre, court room and version");
+        }
+
+        final DiscoverySchedulerConfiguration entity = mapper.toEntity(request);
+        repository.saveAndFlush(entity);
+
+        log.info("Discovery scheduler configuration saved courtCentreId={} courtRoomId={} version={} active={}",
+                entity.getCourtCentreId(), entity.getCourtRoomId(), entity.getVersion(), entity.isActive());
+
+        return mapper.toResponse("Discovery scheduler configuration saved");
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/mapper/DiscoverySchedulerConfigurationMapper.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/mapper/DiscoverySchedulerConfigurationMapper.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.cp.cdk.services.mapper;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import java.util.UUID;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface DiscoverySchedulerConfigurationMapper {
+
+    default DiscoverySchedulerConfiguration toEntity(final DiscoverySchedulerConfigurationRequest request) {
+        final DiscoverySchedulerConfiguration entity = new DiscoverySchedulerConfiguration();
+        entity.setId(UUID.randomUUID());
+        entity.setCourtCentreId(request.getCourtCentreId());
+        entity.setCourtRoomId(request.getCourtRoomId());
+        entity.setUploadedDate(request.getUploadedDate());
+        entity.setVersion(request.getVersion());
+        entity.setActive(Boolean.TRUE.equals(request.getIsActive()));
+        return entity;
+    }
+
+    default UpsertDiscoverySchedulerConfiguration200Response toResponse(final String message) {
+        return new UpsertDiscoverySchedulerConfiguration200Response().message(message);
+    }
+}

--- a/src/main/resources/acl/cdks-rules.drl
+++ b/src/main/resources/acl/cdks-rules.drl
@@ -78,3 +78,12 @@ when
 then
   $o.setSuccess(true);
 end
+
+rule "Allow LA – discovery-scheduler-configuration"
+when
+  $o: Outcome()
+  $a: Action(name == "casedocumentknowledge-service.discovery-scheduler-configuration")
+  eval(userAndGroupProvider.isMemberOfAnyOfTheSuppliedGroups($a, "System Users"))
+then
+  $o.setSuccess(true);
+end

--- a/src/main/resources/db/migration/V1011__create_discovery_scheduler_configuration.sql
+++ b/src/main/resources/db/migration/V1011__create_discovery_scheduler_configuration.sql
@@ -1,0 +1,16 @@
+CREATE TABLE discovery_scheduler_configuration (
+    id UUID PRIMARY KEY,
+    court_centre_id UUID NOT NULL,
+    court_room_id UUID NOT NULL,
+    uploaded_date DATE NOT NULL,
+    version INTEGER NOT NULL,
+    is_active BOOLEAN NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE discovery_scheduler_configuration
+    ADD CONSTRAINT uq_dsc_centre_room_version
+    UNIQUE (court_centre_id, court_room_id, version);
+
+CREATE INDEX idx_dsc_centre_room ON discovery_scheduler_configuration (court_centre_id, court_room_id);

--- a/src/test/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerControllerTest.java
@@ -1,0 +1,129 @@
+package uk.gov.hmcts.cp.cdk.controllers;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import uk.gov.hmcts.cp.cdk.services.DiscoverySchedulerConfigurationService;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.server.ResponseStatusException;
+
+@DisplayName("Discovery Scheduler Controller tests")
+class DiscoverySchedulerControllerTest {
+
+    private static final MediaType VND =
+            MediaType.valueOf("application/vnd.casedocumentknowledge-service.discovery-scheduler-configuration+json");
+
+    private MockMvc mvc(final DiscoverySchedulerConfigurationService service) {
+        return MockMvcBuilders.standaloneSetup(new DiscoverySchedulerController(service)).build();
+    }
+
+    @Test
+    @DisplayName("POST /discovery-scheduler/configurations returns 200 with body")
+    void upsert_returns_200_with_body() throws Exception {
+        final DiscoverySchedulerConfigurationService service = mock(DiscoverySchedulerConfigurationService.class);
+        final MockMvc mvc = mvc(service);
+
+        final UpsertDiscoverySchedulerConfiguration200Response response =
+                new UpsertDiscoverySchedulerConfiguration200Response().message("Discovery scheduler configuration saved");
+        when(service.upsert(ArgumentMatchers.any(DiscoverySchedulerConfigurationRequest.class))).thenReturn(response);
+
+        final String body = """
+                {
+                  "courtCentreId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "courtRoomId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                  "uploadedDate": "2026-06-16",
+                  "version": 1,
+                  "isActive": true
+                }
+                """;
+
+        mvc.perform(post("/discovery-scheduler/configurations")
+                        .contentType(VND).accept(VND)
+                        .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Discovery scheduler configuration saved"));
+
+        verify(service).upsert(ArgumentMatchers.any(DiscoverySchedulerConfigurationRequest.class));
+    }
+
+    @Test
+    @DisplayName("POST /discovery-scheduler/configurations returns 409 on duplicate version")
+    void upsert_returns_409_on_conflict() throws Exception {
+        final DiscoverySchedulerConfigurationService service = mock(DiscoverySchedulerConfigurationService.class);
+        final MockMvc mvc = mvc(service);
+
+        when(service.upsert(ArgumentMatchers.any(DiscoverySchedulerConfigurationRequest.class)))
+                .thenThrow(new ResponseStatusException(org.springframework.http.HttpStatus.CONFLICT,
+                        "Discovery scheduler configuration already exists for this court centre, court room and version"));
+
+        final String body = """
+                {
+                  "courtCentreId": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                  "courtRoomId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                  "uploadedDate": "2026-06-16",
+                  "version": 1,
+                  "isActive": true
+                }
+                """;
+
+        mvc.perform(post("/discovery-scheduler/configurations")
+                        .contentType(VND).accept(VND)
+                        .content(body))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("POST /discovery-scheduler/configurations returns 400 for missing required field")
+    void upsert_returns_400_for_missing_field() throws Exception {
+        final DiscoverySchedulerConfigurationService service = mock(DiscoverySchedulerConfigurationService.class);
+        final MockMvc mvc = mvc(service);
+
+        final String body = """
+                {
+                  "courtRoomId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                  "uploadedDate": "2026-06-16",
+                  "version": 1,
+                  "isActive": true
+                }
+                """;
+
+        mvc.perform(post("/discovery-scheduler/configurations")
+                        .contentType(VND).accept(VND)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /discovery-scheduler/configurations returns 400 for malformed UUID")
+    void upsert_returns_400_for_malformed_uuid() throws Exception {
+        final DiscoverySchedulerConfigurationService service = mock(DiscoverySchedulerConfigurationService.class);
+        final MockMvc mvc = mvc(service);
+
+        final String body = """
+                {
+                  "courtCentreId": "not-a-uuid",
+                  "courtRoomId": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+                  "uploadedDate": "2026-06-16",
+                  "version": 1,
+                  "isActive": true
+                }
+                """;
+
+        mvc.perform(post("/discovery-scheduler/configurations")
+                        .contentType(VND).accept(VND)
+                        .content(body))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepositoryTest.java
@@ -1,0 +1,102 @@
+package uk.gov.hmcts.cp.cdk.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.annotation.Resource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@DataJpaTest
+@Testcontainers
+@DisplayName("Discovery Scheduler Configuration Repository tests")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiscoverySchedulerConfigurationRepositoryTest {
+
+    @Container
+    @ServiceConnection
+    static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("cdk")
+                    .withUsername("postgres")
+                    .withPassword("postgres");
+
+    @Resource
+    private DiscoverySchedulerConfigurationRepository repository;
+
+    private UUID courtCentreId;
+    private UUID courtRoomId;
+
+    @BeforeEach
+    void seed() {
+        courtCentreId = UUID.randomUUID();
+        courtRoomId = UUID.randomUUID();
+
+        repository.saveAndFlush(configuration(courtCentreId, courtRoomId, 1, true));
+        repository.saveAndFlush(configuration(courtCentreId, courtRoomId, 2, false));
+    }
+
+    @Test
+    @DisplayName("findLatestByCourtCentreAndCourtRoom returns highest version for a pair")
+    void findLatestByCourtCentreAndCourtRoom_returns_highest_version() {
+        final Optional<DiscoverySchedulerConfiguration> latest =
+                repository.findLatestByCourtCentreAndCourtRoom(courtCentreId, courtRoomId);
+
+        assertThat(latest).isPresent();
+        assertThat(latest.get().getVersion()).isEqualTo(2);
+        assertThat(latest.get().isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("findLatestByCourtCentreAndCourtRoom ignores lower versions of other pairs")
+    void findLatestByCourtCentreAndCourtRoom_ignores_other_pairs() {
+        final UUID otherCourtRoomId = UUID.randomUUID();
+        repository.saveAndFlush(configuration(courtCentreId, otherCourtRoomId, 1, true));
+
+        final Optional<DiscoverySchedulerConfiguration> latest =
+                repository.findLatestByCourtCentreAndCourtRoom(courtCentreId, courtRoomId);
+
+        assertThat(latest).isPresent();
+        assertThat(latest.get().getVersion()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("findLatestByCourtCentreAndCourtRoom returns empty when none exist")
+    void findLatestByCourtCentreAndCourtRoom_returns_empty_when_none() {
+        final Optional<DiscoverySchedulerConfiguration> latest =
+                repository.findLatestByCourtCentreAndCourtRoom(UUID.randomUUID(), UUID.randomUUID());
+
+        assertThat(latest).isEmpty();
+    }
+
+    @Test
+    @DisplayName("existsByCourtCentreIdAndCourtRoomIdAndVersion detects duplicate version")
+    void existsByCourtCentreIdAndCourtRoomIdAndVersion_detects_duplicate() {
+        assertThat(repository.existsByCourtCentreIdAndCourtRoomIdAndVersion(courtCentreId, courtRoomId, 1)).isTrue();
+        assertThat(repository.existsByCourtCentreIdAndCourtRoomIdAndVersion(courtCentreId, courtRoomId, 3)).isFalse();
+    }
+
+    private static DiscoverySchedulerConfiguration configuration(final UUID courtCentreId, final UUID courtRoomId,
+                                                                   final int version, final boolean active) {
+        final DiscoverySchedulerConfiguration config = new DiscoverySchedulerConfiguration();
+        config.setId(UUID.randomUUID());
+        config.setCourtCentreId(courtCentreId);
+        config.setCourtRoomId(courtRoomId);
+        config.setUploadedDate(LocalDate.of(2026, 6, 16));
+        config.setVersion(version);
+        config.setActive(active);
+        return config;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/repo/DiscoverySchedulerConfigurationRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -79,6 +80,62 @@ class DiscoverySchedulerConfigurationRepositoryTest {
                 repository.findLatestByCourtCentreAndCourtRoom(UUID.randomUUID(), UUID.randomUUID());
 
         assertThat(latest).isEmpty();
+    }
+
+    @Test
+    @DisplayName("findLatestActiveConfigurations skips an inactive latest version and returns the latest active one for the pair")
+    void findLatestActiveConfigurations_skips_inactive_latest() {
+        // seeded: v1 active=true, v2 active=false (v2 is the overall latest, but inactive)
+        final List<DiscoverySchedulerConfiguration> latestActive = repository.findLatestActiveConfigurations();
+
+        final Optional<DiscoverySchedulerConfiguration> forSeededPair = latestActive.stream()
+                .filter(c -> c.getCourtCentreId().equals(courtCentreId) && c.getCourtRoomId().equals(courtRoomId))
+                .findFirst();
+
+        assertThat(forSeededPair).isPresent();
+        assertThat(forSeededPair.get().getVersion()).isEqualTo(1);
+        assertThat(forSeededPair.get().isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("findLatestActiveConfigurations returns the highest active version for a pair, ignoring an inactive version in between")
+    void findLatestActiveConfigurations_returns_highest_active_ignoring_inactive_gap() {
+        repository.saveAndFlush(configuration(courtCentreId, courtRoomId, 3, true));
+
+        final List<DiscoverySchedulerConfiguration> latestActive = repository.findLatestActiveConfigurations();
+
+        final Optional<DiscoverySchedulerConfiguration> forSeededPair = latestActive.stream()
+                .filter(c -> c.getCourtCentreId().equals(courtCentreId) && c.getCourtRoomId().equals(courtRoomId))
+                .findFirst();
+
+        assertThat(forSeededPair).isPresent();
+        assertThat(forSeededPair.get().getVersion()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("findLatestActiveConfigurations excludes pairs with no active version at all")
+    void findLatestActiveConfigurations_excludes_pairs_with_no_active_version() {
+        final UUID centreWithOnlyInactiveVersions = UUID.randomUUID();
+        final UUID roomWithOnlyInactiveVersions = UUID.randomUUID();
+        repository.saveAndFlush(configuration(centreWithOnlyInactiveVersions, roomWithOnlyInactiveVersions, 1, false));
+
+        final List<DiscoverySchedulerConfiguration> latestActive = repository.findLatestActiveConfigurations();
+
+        assertThat(latestActive)
+                .noneMatch(c -> c.getCourtCentreId().equals(centreWithOnlyInactiveVersions)
+                        && c.getCourtRoomId().equals(roomWithOnlyInactiveVersions));
+    }
+
+    @Test
+    @DisplayName("findLatestActiveConfigurations returns exactly one row per court centre/court room pair")
+    void findLatestActiveConfigurations_returns_one_row_per_pair() {
+        final List<DiscoverySchedulerConfiguration> latestActive = repository.findLatestActiveConfigurations();
+
+        final long matchesForSeededPair = latestActive.stream()
+                .filter(c -> c.getCourtCentreId().equals(courtCentreId) && c.getCourtRoomId().equals(courtRoomId))
+                .count();
+
+        assertThat(matchesForSeededPair).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoverySchedulerConfigurationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoverySchedulerConfigurationServiceTest.java
@@ -1,0 +1,90 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
+import uk.gov.hmcts.cp.cdk.services.mapper.DiscoverySchedulerConfigurationMapper;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Discovery Scheduler Configuration Service tests")
+class DiscoverySchedulerConfigurationServiceTest {
+
+    @Mock
+    private DiscoverySchedulerConfigurationRepository repository;
+    @Mock
+    private DiscoverySchedulerConfigurationMapper mapper;
+    @InjectMocks
+    private DiscoverySchedulerConfigurationService service;
+
+    @Test
+    @DisplayName("upsert persists a new version")
+    void upsert_persists_new_version() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+        final DiscoverySchedulerConfigurationRequest request = new DiscoverySchedulerConfigurationRequest()
+                .courtCentreId(courtCentreId)
+                .courtRoomId(courtRoomId)
+                .uploadedDate(LocalDate.of(2026, 6, 16))
+                .version(1)
+                .isActive(true);
+
+        when(repository.existsByCourtCentreIdAndCourtRoomIdAndVersion(courtCentreId, courtRoomId, 1)).thenReturn(false);
+
+        final DiscoverySchedulerConfiguration entity = new DiscoverySchedulerConfiguration();
+        entity.setId(UUID.randomUUID());
+        entity.setCourtCentreId(courtCentreId);
+        entity.setCourtRoomId(courtRoomId);
+        entity.setVersion(1);
+        entity.setActive(true);
+        when(mapper.toEntity(request)).thenReturn(entity);
+
+        final UpsertDiscoverySchedulerConfiguration200Response mappedResponse =
+                new UpsertDiscoverySchedulerConfiguration200Response().message("saved");
+        when(mapper.toResponse(org.mockito.ArgumentMatchers.anyString())).thenReturn(mappedResponse);
+
+        final UpsertDiscoverySchedulerConfiguration200Response response = service.upsert(request);
+
+        assertThat(response).isSameAs(mappedResponse);
+        verify(repository).saveAndFlush(entity);
+    }
+
+    @Test
+    @DisplayName("upsert rejects duplicate courtCentre/courtRoom/version")
+    void upsert_rejects_duplicate() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+        final DiscoverySchedulerConfigurationRequest request = new DiscoverySchedulerConfigurationRequest()
+                .courtCentreId(courtCentreId)
+                .courtRoomId(courtRoomId)
+                .uploadedDate(LocalDate.of(2026, 6, 16))
+                .version(1)
+                .isActive(true);
+
+        when(repository.existsByCourtCentreIdAndCourtRoomIdAndVersion(courtCentreId, courtRoomId, 1)).thenReturn(true);
+
+        final ResponseStatusException ex = assertThrows(ResponseStatusException.class, () -> service.upsert(request));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        verify(repository, never()).saveAndFlush(any());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/mapper/DiscoverySchedulerConfigurationMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/mapper/DiscoverySchedulerConfigurationMapperTest.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.cp.cdk.services.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Discovery Scheduler Configuration Mapper tests")
+class DiscoverySchedulerConfigurationMapperTest {
+
+    private final DiscoverySchedulerConfigurationMapper mapper = new DiscoverySchedulerConfigurationMapper() {
+    };
+
+    @Test
+    @DisplayName("toEntity maps all request fields and assigns a new id")
+    void toEntity_maps_all_fields() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+        final DiscoverySchedulerConfigurationRequest request = new DiscoverySchedulerConfigurationRequest()
+                .courtCentreId(courtCentreId)
+                .courtRoomId(courtRoomId)
+                .uploadedDate(LocalDate.of(2026, 6, 16))
+                .version(1)
+                .isActive(true);
+
+        final DiscoverySchedulerConfiguration entity = mapper.toEntity(request);
+
+        assertThat(entity.getId()).isNotNull();
+        assertThat(entity.getCourtCentreId()).isEqualTo(courtCentreId);
+        assertThat(entity.getCourtRoomId()).isEqualTo(courtRoomId);
+        assertThat(entity.getUploadedDate()).isEqualTo(LocalDate.of(2026, 6, 16));
+        assertThat(entity.getVersion()).isEqualTo(1);
+        assertThat(entity.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("toResponse maps message")
+    void toResponse_maps_message() {
+        final UpsertDiscoverySchedulerConfiguration200Response response = mapper.toResponse("saved");
+
+        assertThat(response.getMessage()).isEqualTo("saved");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds versioned discovery scheduler configuration storage (court centre / court room pairs) via `POST /discovery-scheduler/configurations`, implementing the generated `DiscoverySchedulerApi` contract (no hand-written mappings).
- New Flyway migration `V1011__create_discovery_scheduler_configuration.sql`, entity/repository/service/mapper/controller built via strict TDD (failing test first for every layer).
- Repository supports both "latest version overall" and "latest **active** version" lookups per court centre/court room pair — the latter skips a newer inactive version and falls back to the latest active one, and returns one row per pair across the whole table (`findLatestActiveConfigurations`).
- New Drools rule gates the endpoint (`casedocumentknowledge-service.discovery-scheduler-configuration`, System Users group only).
- Updated `.claude/context/csdk-context.md` and `tech-stack.md` to reflect the new migration, entity/repo counts, API surface, and RBAC exception.

Out of scope for this PR (by design): the nightly `DiscoveryScheduler` job itself is not implemented yet — only the persistence/service/controller layer it will read from.

## Test plan
- [x] `./gradlew test` — full unit suite green
- [x] `./gradlew integration` — full docker-compose-backed suite green (incl. new `DiscoverySchedulerConfigurationHttpLiveTest`)
- [x] `./gradlew pmdMain pmdTest` — clean, no threshold changes
- [x] `./gradlew jacocoTestReport` — generated, no threshold changes
- [ ] CI pipeline (this PR) — to be confirmed once triggered

## Open items
- No Jira ticket linked yet for this story.
- Nightly scheduler class (consuming `findLatestActiveConfigurations`) not yet implemented — follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)