### PR TITLE
DD-42938 - Update nightly schedule to get courtcentre and case details using /hearing-cases-for-day

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
@@ -1,13 +1,14 @@
 package uk.gov.hmcts.cp.cdk.scheduler;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub.stubGetHearingCasesForDayReturnsHearingCase;
-import static uk.gov.hmcts.cp.cdk.stub.ProgressionQueryApiStub.stubGetProsecutionCaseEligibilityInfoReturnsEmpty;
+import static uk.gov.hmcts.cp.cdk.stub.ProgressionQueryApiStub.stubGetCourtDocumentsForAllDefendantsReturnsEmpty;
 
 import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 
@@ -28,15 +29,16 @@ import org.junit.jupiter.api.Test;
  * Verifies that NightlyDiscoveryScheduler acquires a ShedLock, calculates the
  * upcoming hearing-date window, calls the hearing-cases-for-day API for each
  * calculated date, and — once a retrieved hearing case matches an active
- * court-centre/room configuration — dispatches a check-case-eligibility task whose
- * downstream execution calls the prosecution-case eligibility API. The docker-compose
- * stack overrides the cron to fire every 30 seconds so tests complete well under a minute.
+ * court-centre/room configuration — dispatches a check-idpc-availability task whose
+ * downstream execution calls the court-document-search API for all defendants on the
+ * case. The docker-compose stack overrides the cron to fire every 30 seconds so tests
+ * complete well under a minute.
  */
 class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
 
     private static final String LOCK_NAME = "nightlyDiscoveryScheduler";
     private static final String HEARING_CASES_FOR_DAY_PATH = "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day";
-    private static final String PROSECUTION_CASE_PATH_PREFIX = "/progression-query-api/query/api/rest/progression/prosecutioncases/";
+    private static final String COURT_DOCUMENT_SEARCH_PATH = "/progression-query-api/query/api/rest/progression/courtdocumentsearch";
 
     @Test
     void scheduler_shouldAcquireShedLock_andPopulateShedlockTable() throws SQLException {
@@ -90,13 +92,14 @@ class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
         // Nightly discovery retrieves hearing cases for every calculated hearing date and
         // matches them against active court-centre/room configurations. Returning a hearing
         // case whose centre/room match the seeded configuration exercises the full flow:
-        // whitelist match -> dispatchCaseDocumentIngestionTasksCheckCaseEligibility ->
-        // CheckCaseEligibilityTask -> ProgressionClient.getProsecutionCaseEligibilityInfo.
-        // The eligibility API is stubbed to return an empty body so the task completes
-        // without a defendant to chain onto CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS.
+        // whitelist match -> dispatchCaseDocumentIngestionTasksCheckIdpcAvailability ->
+        // CheckIdpcAvailabilityAllDefendantsTask -> IdpcAvailabilityService.retrieveDocuments ->
+        // ProgressionClient.getCourtDocumentsForAllDefendants. The court-document-search API is
+        // stubbed to return no documents so the task completes without dispatching
+        // RETRIEVE_MATERIAL_AND_UPLOAD for any defendant.
         insertDiscoverySchedulerConfiguration(configurationId, courtCentreId, roomId);
         stubGetHearingCasesForDayReturnsHearingCase(courtCentreId.toString(), roomId.toString(), caseId.toString());
-        stubGetProsecutionCaseEligibilityInfoReturnsEmpty(caseId.toString());
+        stubGetCourtDocumentsForAllDefendantsReturnsEmpty(caseId.toString());
 
         try {
             Awaitility.await()
@@ -108,14 +111,15 @@ class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
                     .as("hearing-cases-for-day API must be called by nightly discovery for the calculated hearing dates")
                     .isNotEmpty();
 
-            final String eligibilityPath = PROSECUTION_CASE_PATH_PREFIX + caseId;
             Awaitility.await()
                     .atMost(Duration.ofSeconds(90))
                     .pollInterval(Duration.ofSeconds(5))
-                    .until(() -> !findAll(getRequestedFor(urlPathEqualTo(eligibilityPath))).isEmpty());
+                    .until(() -> !findAll(getRequestedFor(urlPathEqualTo(COURT_DOCUMENT_SEARCH_PATH))
+                            .withQueryParam("caseId", equalTo(caseId.toString()))).isEmpty());
 
-            assertThat(findAll(getRequestedFor(urlPathEqualTo(eligibilityPath))))
-                    .as("prosecution-case eligibility API must be called for the whitelisted matched hearing case caseId=%s", caseId)
+            assertThat(findAll(getRequestedFor(urlPathEqualTo(COURT_DOCUMENT_SEARCH_PATH))
+                    .withQueryParam("caseId", equalTo(caseId.toString()))))
+                    .as("court-document-search API must be called for all defendants on the whitelisted matched hearing case caseId=%s", caseId)
                     .isNotEmpty();
         } finally {
             deleteDiscoverySchedulerConfiguration(configurationId);

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
@@ -1,13 +1,12 @@
 package uk.gov.hmcts.cp.cdk.scheduler;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub.stubGetHearingsReturnsEmptyHearingSummaries;
+import static uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub.stubGetHearingCasesForDayReturnsEmptyHearingCases;
 
 import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 
@@ -26,15 +25,15 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that NightlyDiscoveryScheduler acquires a ShedLock, calculates the
- * upcoming hearing-date window, and dispatches ingestion tasks for every active
- * court-centre/room configuration across that window. The docker-compose stack
- * overrides the cron to fire every 30 seconds so tests complete well under a minute.
+ * upcoming hearing-date window, and calls the hearing-cases-for-day API for each
+ * calculated date so retrieved cases can be matched against active court-centre/room
+ * configurations. The docker-compose stack overrides the cron to fire every 30
+ * seconds so tests complete well under a minute.
  */
 class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
 
     private static final String LOCK_NAME = "nightlyDiscoveryScheduler";
-    private static final String HEARINGS_PATH = "/hearing-query-api/query/api/rest/hearing/hearings";
-    private static final String COURT_CENTRE_ID = "courtCentreId";
+    private static final String HEARING_CASES_FOR_DAY_PATH = "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day";
 
     @Test
     void scheduler_shouldAcquireShedLock_andPopulateShedlockTable() throws SQLException {
@@ -77,29 +76,27 @@ class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
     }
 
     @Test
-    void scheduler_shouldCallHearingApi_forActiveCourtCentreConfigurations() throws SQLException {
+    void scheduler_shouldCallHearingCasesForDayApi_forCalculatedHearingDates() throws SQLException {
         configureFor("localhost", 8089);
 
         final UUID courtCentreId = randomUUID();
         final UUID roomId = randomUUID();
         final UUID configurationId = randomUUID();
 
-        // Nightly discovery dispatches one task per active court-centre/room
-        // configuration for every calculated hearing date; seeding one active
-        // configuration is enough for the scheduler to pick it up.
+        // Nightly discovery retrieves hearing cases for every calculated hearing date
+        // and matches them against active court-centre/room configurations; seeding
+        // one active configuration is enough to exercise the whitelisting flow.
         insertDiscoverySchedulerConfiguration(configurationId, courtCentreId, roomId);
-        stubGetHearingsReturnsEmptyHearingSummaries(courtCentreId.toString(), roomId.toString());
+        stubGetHearingCasesForDayReturnsEmptyHearingCases();
 
         try {
             Awaitility.await()
                     .atMost(Duration.ofSeconds(90))
                     .pollInterval(Duration.ofSeconds(5))
-                    .until(() -> !findAll(getRequestedFor(urlPathEqualTo(HEARINGS_PATH))
-                            .withQueryParam(COURT_CENTRE_ID, equalTo(courtCentreId.toString()))).isEmpty());
+                    .until(() -> !findAll(getRequestedFor(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))).isEmpty());
 
-            assertThat(findAll(getRequestedFor(urlPathEqualTo(HEARINGS_PATH))
-                    .withQueryParam(COURT_CENTRE_ID, equalTo(courtCentreId.toString()))))
-                    .as("hearing API must be called for nightly-discovery active configuration courtCentreId=%s", courtCentreId)
+            assertThat(findAll(getRequestedFor(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))))
+                    .as("hearing-cases-for-day API must be called by nightly discovery for the calculated hearing dates")
                     .isNotEmpty();
         } finally {
             deleteDiscoverySchedulerConfiguration(configurationId);

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/scheduler/NightlyDiscoverySchedulerLiveTest.java
@@ -6,7 +6,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static java.util.UUID.randomUUID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub.stubGetHearingCasesForDayReturnsEmptyHearingCases;
+import static uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub.stubGetHearingCasesForDayReturnsHearingCase;
+import static uk.gov.hmcts.cp.cdk.stub.ProgressionQueryApiStub.stubGetProsecutionCaseEligibilityInfoReturnsEmpty;
 
 import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 
@@ -25,15 +26,17 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Verifies that NightlyDiscoveryScheduler acquires a ShedLock, calculates the
- * upcoming hearing-date window, and calls the hearing-cases-for-day API for each
- * calculated date so retrieved cases can be matched against active court-centre/room
- * configurations. The docker-compose stack overrides the cron to fire every 30
- * seconds so tests complete well under a minute.
+ * upcoming hearing-date window, calls the hearing-cases-for-day API for each
+ * calculated date, and — once a retrieved hearing case matches an active
+ * court-centre/room configuration — dispatches a check-case-eligibility task whose
+ * downstream execution calls the prosecution-case eligibility API. The docker-compose
+ * stack overrides the cron to fire every 30 seconds so tests complete well under a minute.
  */
 class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
 
     private static final String LOCK_NAME = "nightlyDiscoveryScheduler";
     private static final String HEARING_CASES_FOR_DAY_PATH = "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day";
+    private static final String PROSECUTION_CASE_PATH_PREFIX = "/progression-query-api/query/api/rest/progression/prosecutioncases/";
 
     @Test
     void scheduler_shouldAcquireShedLock_andPopulateShedlockTable() throws SQLException {
@@ -82,12 +85,18 @@ class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
         final UUID courtCentreId = randomUUID();
         final UUID roomId = randomUUID();
         final UUID configurationId = randomUUID();
+        final UUID caseId = randomUUID();
 
-        // Nightly discovery retrieves hearing cases for every calculated hearing date
-        // and matches them against active court-centre/room configurations; seeding
-        // one active configuration is enough to exercise the whitelisting flow.
+        // Nightly discovery retrieves hearing cases for every calculated hearing date and
+        // matches them against active court-centre/room configurations. Returning a hearing
+        // case whose centre/room match the seeded configuration exercises the full flow:
+        // whitelist match -> dispatchCaseDocumentIngestionTasksCheckCaseEligibility ->
+        // CheckCaseEligibilityTask -> ProgressionClient.getProsecutionCaseEligibilityInfo.
+        // The eligibility API is stubbed to return an empty body so the task completes
+        // without a defendant to chain onto CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS.
         insertDiscoverySchedulerConfiguration(configurationId, courtCentreId, roomId);
-        stubGetHearingCasesForDayReturnsEmptyHearingCases();
+        stubGetHearingCasesForDayReturnsHearingCase(courtCentreId.toString(), roomId.toString(), caseId.toString());
+        stubGetProsecutionCaseEligibilityInfoReturnsEmpty(caseId.toString());
 
         try {
             Awaitility.await()
@@ -97,6 +106,16 @@ class NightlyDiscoverySchedulerLiveTest extends AbstractHttpLiveTest {
 
             assertThat(findAll(getRequestedFor(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))))
                     .as("hearing-cases-for-day API must be called by nightly discovery for the calculated hearing dates")
+                    .isNotEmpty();
+
+            final String eligibilityPath = PROSECUTION_CASE_PATH_PREFIX + caseId;
+            Awaitility.await()
+                    .atMost(Duration.ofSeconds(90))
+                    .pollInterval(Duration.ofSeconds(5))
+                    .until(() -> !findAll(getRequestedFor(urlPathEqualTo(eligibilityPath))).isEmpty());
+
+            assertThat(findAll(getRequestedFor(urlPathEqualTo(eligibilityPath))))
+                    .as("prosecution-case eligibility API must be called for the whitelisted matched hearing case caseId=%s", caseId)
                     .isNotEmpty();
         } finally {
             deleteDiscoverySchedulerConfiguration(configurationId);

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
@@ -51,7 +51,7 @@ public class HearingQueryApiStub {
                                   "courtRoomId":"%s",
                                   "hearingDate":"2026-07-15",
                                   "hearingId":"%s",
-                                  "prosecutionCases":[{"caseId":"%s"}]
+                                  "prosecutionCases":["%s"]
                                 }]}"""
                                 .formatted(courtCentreId, courtRoomId, UUID.randomUUID(), caseId))
                 ));

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
@@ -8,6 +8,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.apache.http.HttpStatus.SC_OK;
 
+import java.util.UUID;
+
 public class HearingQueryApiStub {
 
     private static final String HEARINGS_PATH = "/hearing-query-api/query/api/rest/hearing/hearings";
@@ -33,6 +35,25 @@ public class HearingQueryApiStub {
                         .withStatus(SC_OK)
                         .withHeader("Content-Type", APPLICATION_JSON)
                         .withBody("{\"hearingCases\":[]}")
+                ));
+    }
+
+    public static void stubGetHearingCasesForDayReturnsHearingCase(final String courtCentreId, final String courtRoomId,
+                                                                    final String caseId) {
+        stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
+                .withQueryParam("date", matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(SC_OK)
+                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withBody("""
+                                {"hearingCases":[{
+                                  "courtCentreId":"%s",
+                                  "courtRoomId":"%s",
+                                  "hearingDate":"2026-07-15",
+                                  "hearingId":"%s",
+                                  "prosecutionCases":[{"caseId":"%s"}]
+                                }]}"""
+                                .formatted(courtCentreId, courtRoomId, UUID.randomUUID(), caseId))
                 ));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
@@ -11,6 +11,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 public class HearingQueryApiStub {
 
     private static final String HEARINGS_PATH = "/hearing-query-api/query/api/rest/hearing/hearings";
+    private static final String HEARING_CASES_FOR_DAY_PATH = "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day";
     public static final String APPLICATION_JSON = "application/json";
 
     public static void stubGetHearingsReturnsEmptyHearingSummaries(final String courtCentreId, final String roomId) {
@@ -22,6 +23,16 @@ public class HearingQueryApiStub {
                         .withStatus(SC_OK)
                         .withHeader("Content-Type", APPLICATION_JSON)
                         .withBody("{\"hearingSummaries\":[]}")
+                ));
+    }
+
+    public static void stubGetHearingCasesForDayReturnsEmptyHearingCases() {
+        stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
+                .withQueryParam("date", matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(SC_OK)
+                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withBody("{\"hearingCases\":[]}")
                 ));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/ProgressionQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/ProgressionQueryApiStub.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.cp.cdk.stub;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
@@ -8,15 +9,16 @@ import static org.apache.http.HttpStatus.SC_OK;
 
 public class ProgressionQueryApiStub {
 
-    private static final String PROSECUTION_CASE_PATH_PREFIX = "/progression-query-api/query/api/rest/progression/prosecutioncases/";
+    private static final String COURT_DOCUMENT_SEARCH_PATH = "/progression-query-api/query/api/rest/progression/courtdocumentsearch";
     public static final String APPLICATION_JSON = "application/json";
 
-    public static void stubGetProsecutionCaseEligibilityInfoReturnsEmpty(final String caseId) {
-        stubFor(get(urlPathEqualTo(PROSECUTION_CASE_PATH_PREFIX + caseId))
+    public static void stubGetCourtDocumentsForAllDefendantsReturnsEmpty(final String caseId) {
+        stubFor(get(urlPathEqualTo(COURT_DOCUMENT_SEARCH_PATH))
+                .withQueryParam("caseId", equalTo(caseId))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
                         .withHeader("Content-Type", APPLICATION_JSON)
-                        .withBody("{}")
+                        .withBody("{\"documentIndices\":[]}")
                 ));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/ProgressionQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/ProgressionQueryApiStub.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.cp.cdk.stub;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.apache.http.HttpStatus.SC_OK;
+
+public class ProgressionQueryApiStub {
+
+    private static final String PROSECUTION_CASE_PATH_PREFIX = "/progression-query-api/query/api/rest/progression/prosecutioncases/";
+    public static final String APPLICATION_JSON = "application/json";
+
+    public static void stubGetProsecutionCaseEligibilityInfoReturnsEmpty(final String caseId) {
+        stubFor(get(urlPathEqualTo(PROSECUTION_CASE_PATH_PREFIX + caseId))
+                .willReturn(aResponse()
+                        .withStatus(SC_OK)
+                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withBody("{}")
+                ));
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClient.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClient.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cp.cdk.clients.hearing;
 
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesInfo;
 
 import java.time.LocalDate;
@@ -8,4 +9,6 @@ import java.util.List;
 @SuppressWarnings("PMD.ImplicitFunctionalInterface")
 public interface HearingClient {
     List<HearingSummariesInfo> getHearingsAndCases(String courtId, String roomId, LocalDate date, String userId);
+
+    List<HearingCaseForDay> getHearingCasesForDay(LocalDate date, String userId);
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientConfig.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientConfig.java
@@ -4,7 +4,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "cqrs.client.hearing")
 public record HearingClientConfig(
-        String acceptHeader,
-        String hearingsPath
+        String getHearingsAcceptHeader,
+        String getHearingsPath,
+        String getHearingCasesForDayAcceptHeader,
+        String getHearingCasesForDayPath
 ) {
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImpl.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImpl.java
@@ -1,7 +1,11 @@
 package uk.gov.hmcts.cp.cdk.clients.hearing;
 
 
+import static java.util.Objects.isNull;
+
 import uk.gov.hmcts.cp.cdk.clients.common.CQRSClientProperties;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCasesForDayResponse;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummaries;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesInfo;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesListRequest;
@@ -27,6 +31,8 @@ public class HearingClientImpl implements HearingClient {
     private final String acceptHeader;
     private final String cppuidHeaderName;
     private final String hearingsPath;
+    private final String hearingCasesForDayAcceptHeader;
+    private final String hearingCasesForDayPath;
     private final HearingDtoMapper mapper;
 
 
@@ -35,9 +41,13 @@ public class HearingClientImpl implements HearingClient {
                              final HearingClientConfig hearingProps,
                              final HearingDtoMapper mapper) {
         this.restClient = Objects.requireNonNull(restClient, "restClient");
-        this.acceptHeader = Objects.requireNonNull(hearingProps.acceptHeader(), "acceptHeader");
+        this.acceptHeader = Objects.requireNonNull(hearingProps.getHearingsAcceptHeader(), "acceptHeader");
         this.cppuidHeaderName = Objects.requireNonNull(rootProps.headers().cjsCppuid(), "cjsCppuidHeader");
-        this.hearingsPath = Objects.requireNonNull(hearingProps.hearingsPath(), "hearingsPath");
+        this.hearingsPath = Objects.requireNonNull(hearingProps.getHearingsPath(), "hearingsPath");
+        this.hearingCasesForDayAcceptHeader = Objects.requireNonNull(
+                hearingProps.getHearingCasesForDayAcceptHeader(), "hearingCasesForDayAcceptHeader");
+        this.hearingCasesForDayPath = Objects.requireNonNull(
+                hearingProps.getHearingCasesForDayPath(), "hearingCasesForDayPath");
         this.mapper = Objects.requireNonNull(mapper, "mapper");
     }
 
@@ -71,5 +81,28 @@ public class HearingClientImpl implements HearingClient {
             resultIds.addAll(mapper.collectProsecutionCaseIds(hs));
         }
         return mapper.toHearingSummariesInfo(resultIds);
+    }
+
+    @Override
+    @SuppressWarnings({"PMD.OnlyOneReturn", "PMD.UseExplicitTypes"})
+    public List<HearingCaseForDay> getHearingCasesForDay(final LocalDate date, final String userId) {
+        final URI uriHearingCasesForDay = UriComponentsBuilder
+                .fromPath(hearingCasesForDayPath)
+                .queryParam("date", date)
+                .build()
+                .toUri();
+
+        final HearingCasesForDayResponse response = restClient.get()
+                .uri(uriHearingCasesForDay)
+                .header(cppuidHeaderName, userId)
+                .header(HttpHeaders.ACCEPT, hearingCasesForDayAcceptHeader)
+                .retrieve()
+                .body(HearingCasesForDayResponse.class);
+
+        if (isNull(response) || isNull(response.hearingCases())) {
+            return List.of();
+        }
+
+        return response.hearingCases();
     }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseForDay.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseForDay.java
@@ -1,0 +1,14 @@
+package uk.gov.hmcts.cp.cdk.clients.hearing.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public record HearingCaseForDay(
+        UUID courtCentreId,
+        UUID courtRoomId,
+        LocalDate hearingDate,
+        UUID hearingId,
+        List<HearingCaseProsecutionCase> prosecutionCases
+) {
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseForDay.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseForDay.java
@@ -9,6 +9,6 @@ public record HearingCaseForDay(
         UUID courtRoomId,
         LocalDate hearingDate,
         UUID hearingId,
-        List<HearingCaseProsecutionCase> prosecutionCases
+        List<UUID> prosecutionCases
 ) {
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseProsecutionCase.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseProsecutionCase.java
@@ -1,8 +1,0 @@
-package uk.gov.hmcts.cp.cdk.clients.hearing.dto;
-
-import java.util.UUID;
-
-public record HearingCaseProsecutionCase(
-        UUID caseId
-) {
-}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseProsecutionCase.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCaseProsecutionCase.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.cp.cdk.clients.hearing.dto;
+
+import java.util.UUID;
+
+public record HearingCaseProsecutionCase(
+        UUID caseId
+) {
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCasesForDayResponse.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/clients/hearing/dto/HearingCasesForDayResponse.java
@@ -1,0 +1,6 @@
+package uk.gov.hmcts.cp.cdk.clients.hearing.dto;
+
+import java.util.List;
+
+public record HearingCasesForDayResponse(List<HearingCaseForDay> hearingCases) {
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -1,15 +1,14 @@
 package uk.gov.hmcts.cp.cdk.services;
 
 import static java.util.Objects.nonNull;
-import static java.util.UUID.fromString;
 import static java.util.UUID.randomUUID;
-import static org.springframework.util.StringUtils.hasText;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_KEY;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.COURT_CENTRE_ID;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.CPPUID;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.DATE;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.REQUEST_ID;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.ROOM_ID;
-import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.DATE;
+import static uk.gov.hmcts.cp.cdk.util.EnvironmentUtil.getSystemUserId;
 
 import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
@@ -29,7 +28,6 @@ import java.util.stream.Collectors;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -37,7 +35,6 @@ import org.springframework.stereotype.Service;
 @Service
 public class DiscoveryService {
 
-    private static final String CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID = "CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID";
     private final JobManagerService jobManagerService;
     private final ScheduledIngestionRequestRepository scheduledIngestionRequestRepository;
     private final DiscoverySchedulerConfigurationRepository discoverySchedulerConfigurationRepository;
@@ -126,7 +123,7 @@ public class DiscoveryService {
     private void dispatchCaseEligibilityCheck(final UUID caseId, final UUID cpSystemUserId) {
         final JsonObject jobData = toJobDataForCaseEligibility(caseId, cpSystemUserId);
         try {
-            jobManagerService.dispatchCaseDocumentIngestionTasksCheckCaseEligibility(jobData);
+            jobManagerService.dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(jobData);
         } catch (Exception e) {
             log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
         }
@@ -149,19 +146,5 @@ public class DiscoveryService {
                 .add(ROOM_ID, roomId)
                 .add(DATE, date)
                 .build();
-    }
-
-    private static @NotNull UUID getSystemUserId(final Environment environment) {
-        final String configuredSystemUserId = environment.getProperty(CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID);
-        if (!hasText(configuredSystemUserId)) {
-            throw new IllegalStateException("Required environment variable '" + CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID + "' is not set.");
-        }
-
-        try {
-            return fromString(configuredSystemUserId);
-        } catch (IllegalArgumentException e) {
-            throw new IllegalStateException(
-                    "Environment variable '" + CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID + "' must contain a valid UUID, but was: '" + configuredSystemUserId + "'.", e);
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -134,7 +134,7 @@ public class DiscoveryService {
         }
     }
 
-    private static JsonObject toJobDataForCaseEligibility(final UUID caseId, final UUID cpSystemUserId) {
+    private JsonObject toJobDataForCaseEligibility(final UUID caseId, final UUID cpSystemUserId) {
         return Json.createObjectBuilder()
                 .add(REQUEST_ID, randomUUID().toString())
                 .add(CPPUID, cpSystemUserId.toString())

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -1,9 +1,15 @@
 package uk.gov.hmcts.cp.cdk.services;
 
+import static java.util.Objects.nonNull;
 import static java.util.UUID.fromString;
 import static java.util.UUID.randomUUID;
 import static org.springframework.util.StringUtils.hasText;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_KEY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.CPPUID;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.REQUEST_ID;
 
+import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 import uk.gov.hmcts.cp.cdk.domain.ScheduledIngestionRequest;
 import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
@@ -30,6 +36,8 @@ public class DiscoveryService {
     private final ScheduledIngestionRequestRepository scheduledIngestionRequestRepository;
     private final DiscoverySchedulerConfigurationRepository discoverySchedulerConfigurationRepository;
     private final HearingDaysCalculator hearingDaysCalculator;
+    private final HearingClient hearingClient;
+    private final HearingCaseWhitelistSelector hearingCaseWhitelistSelector;
     private final SchedulerProperties schedulerProperties;
     private final Environment environment;
 
@@ -37,12 +45,16 @@ public class DiscoveryService {
                             final ScheduledIngestionRequestRepository scheduledIngestionRequestRepository,
                             final DiscoverySchedulerConfigurationRepository discoverySchedulerConfigurationRepository,
                             final HearingDaysCalculator hearingDaysCalculator,
+                            final HearingClient hearingClient,
+                            final HearingCaseWhitelistSelector hearingCaseWhitelistSelector,
                             final SchedulerProperties schedulerProperties,
                             final Environment environment) {
         this.jobManagerService = jobManagerService;
         this.scheduledIngestionRequestRepository = scheduledIngestionRequestRepository;
         this.discoverySchedulerConfigurationRepository = discoverySchedulerConfigurationRepository;
         this.hearingDaysCalculator = hearingDaysCalculator;
+        this.hearingClient = hearingClient;
+        this.hearingCaseWhitelistSelector = hearingCaseWhitelistSelector;
         this.schedulerProperties = schedulerProperties;
         this.environment = environment;
     }
@@ -60,7 +72,7 @@ public class DiscoveryService {
                         ir.getCourtRoomId().toString(), hearingDate.toString()))
                 .forEach(jobData -> {
                     try {
-                        jobManagerService.dispatchCaseDocumentIngestionTasks(jobData);
+                        jobManagerService.dispatchCaseDocumentIngestionTasksGetCasesForHearing(jobData);
                     } catch (Exception e) {
                         log.error("Intraday Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
                     }
@@ -78,20 +90,38 @@ public class DiscoveryService {
 
         final List<DiscoverySchedulerConfiguration> activeCourtCentreConfigurations = discoverySchedulerConfigurationRepository.findLatestActiveConfigurations();
         final UUID cpSystemUserId = getSystemUserId(environment);
-        log.info("Nightly discovery for active courtCentre configurations={} is made using the CPP SystemUser={}", activeCourtCentreConfigurations.size(), cpSystemUserId);
+        log.info("Nightly discovery for active courtCentre configurations={} is made using the CPP SystemUser={}",
+                activeCourtCentreConfigurations.size(), cpSystemUserId);
 
-        activeCourtCentreConfigurations.forEach(acc -> {
-            hearingDates.stream()
-                    .map(hd -> toJobData(cpSystemUserId.toString(), acc.getCourtCentreId().toString(),
-                            acc.getCourtRoomId().toString(), hd.toString()))
-                    .forEach(jobData -> {
-                        try {
-                            jobManagerService.dispatchCaseDocumentIngestionTasks(jobData);
-                        } catch (Exception e) {
-                            log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
-                        }
-                    });
+        hearingDates.forEach(hearingDate -> {
+            final List<HearingCaseForDay> hearingCases = hearingClient.getHearingCasesForDay(hearingDate, cpSystemUserId.toString());
+            final List<HearingCaseForDay> matchedHearingCases = hearingCaseWhitelistSelector.findMatchingCases(hearingCases, activeCourtCentreConfigurations);
+            log.info("Nightly discovery matched hearingCases={} out of retrieved={} for hearingDate={}",
+                    matchedHearingCases.size(), hearingCases.size(), hearingDate);
+
+            matchedHearingCases.forEach(hearingCase -> {
+                if (nonNull(hearingCase.prosecutionCases())) {
+                    hearingCase.prosecutionCases()
+                            .stream()
+                            .map(pCase -> toJobDataCaseEligibility(pCase.caseId(), cpSystemUserId))
+                            .forEach(jobData -> {
+                                try {
+                                    jobManagerService.dispatchCaseDocumentIngestionTasksCheckCaseEligibility(jobData);
+                                } catch (Exception e) {
+                                    log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
+                                }
+                            });
+                }
+            });
         });
+    }
+
+    private static JsonObject toJobDataCaseEligibility(final UUID caseId, final UUID cpSystemUserId) {
+        return Json.createObjectBuilder()
+                .add(REQUEST_ID, randomUUID().toString())
+                .add(CPPUID, cpSystemUserId.toString())
+                .add(CTX_CASE_ID_KEY, caseId.toString())
+                .build();
     }
 
     private JsonObject toJobData(final String cppUid, final String courtCentreId,

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -13,7 +13,6 @@ import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.DATE;
 
 import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
-import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 import uk.gov.hmcts.cp.cdk.domain.ScheduledIngestionRequest;
 import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
@@ -107,7 +106,6 @@ public class DiscoveryService {
         final Set<UUID> uniqueCaseIds = matchedHearingCases.stream()
                 .filter(hearingCase -> nonNull(hearingCase.prosecutionCases()))
                 .flatMap(hearingCase -> hearingCase.prosecutionCases().stream())
-                .map(HearingCaseProsecutionCase::caseId)
                 .collect(Collectors.toCollection(LinkedHashSet::new));
 
         log.info("Nightly discovery dispatching case eligibility checks for uniqueCaseIds={} out of matchedHearingCases={}",

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -5,11 +5,15 @@ import static java.util.UUID.fromString;
 import static java.util.UUID.randomUUID;
 import static org.springframework.util.StringUtils.hasText;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_KEY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.COURT_CENTRE_ID;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.CPPUID;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.REQUEST_ID;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.ROOM_ID;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.Params.DATE;
 
 import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 import uk.gov.hmcts.cp.cdk.domain.ScheduledIngestionRequest;
 import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
@@ -17,8 +21,11 @@ import uk.gov.hmcts.cp.cdk.repo.ScheduledIngestionRequestRepository;
 import uk.gov.hmcts.cp.cdk.scheduler.SchedulerProperties;
 
 import java.time.LocalDate;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
@@ -68,7 +75,7 @@ public class DiscoveryService {
         final List<ScheduledIngestionRequest> ingestionRequestList = scheduledIngestionRequestRepository.findAllByHearingDate(hearingDate);
         ingestionRequestList
                 .stream()
-                .map(ir -> toJobData(ir.getCppuid().toString(), ir.getCourtCentreId().toString(),
+                .map(ir -> toJobDataForGetCaseHearings(ir.getCppuid().toString(), ir.getCourtCentreId().toString(),
                         ir.getCourtRoomId().toString(), hearingDate.toString()))
                 .forEach(jobData -> {
                     try {
@@ -93,30 +100,41 @@ public class DiscoveryService {
         log.info("Nightly discovery for active courtCentre configurations={} is made using the CPP SystemUser={}",
                 activeCourtCentreConfigurations.size(), cpSystemUserId);
 
-        hearingDates.forEach(hearingDate -> {
-            final List<HearingCaseForDay> hearingCases = hearingClient.getHearingCasesForDay(hearingDate, cpSystemUserId.toString());
-            final List<HearingCaseForDay> matchedHearingCases = hearingCaseWhitelistSelector.findMatchingCases(hearingCases, activeCourtCentreConfigurations);
-            log.info("Nightly discovery matched hearingCases={} out of retrieved={} for hearingDate={}",
-                    matchedHearingCases.size(), hearingCases.size(), hearingDate);
+        final List<HearingCaseForDay> matchedHearingCases = hearingDates.stream()
+                .flatMap(hearingDate -> matchHearingCasesForDate(hearingDate, cpSystemUserId, activeCourtCentreConfigurations).stream())
+                .toList();
 
-            matchedHearingCases.forEach(hearingCase -> {
-                if (nonNull(hearingCase.prosecutionCases())) {
-                    hearingCase.prosecutionCases()
-                            .stream()
-                            .map(pCase -> toJobDataCaseEligibility(pCase.caseId(), cpSystemUserId))
-                            .forEach(jobData -> {
-                                try {
-                                    jobManagerService.dispatchCaseDocumentIngestionTasksCheckCaseEligibility(jobData);
-                                } catch (Exception e) {
-                                    log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
-                                }
-                            });
-                }
-            });
-        });
+        final Set<UUID> uniqueCaseIds = matchedHearingCases.stream()
+                .filter(hearingCase -> nonNull(hearingCase.prosecutionCases()))
+                .flatMap(hearingCase -> hearingCase.prosecutionCases().stream())
+                .map(HearingCaseProsecutionCase::caseId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        log.info("Nightly discovery dispatching case eligibility checks for uniqueCaseIds={} out of matchedHearingCases={}",
+                uniqueCaseIds.size(), matchedHearingCases.size());
+
+        uniqueCaseIds.forEach(caseId -> dispatchCaseEligibilityCheck(caseId, cpSystemUserId));
     }
 
-    private static JsonObject toJobDataCaseEligibility(final UUID caseId, final UUID cpSystemUserId) {
+    private List<HearingCaseForDay> matchHearingCasesForDate(final LocalDate hearingDate, final UUID cpSystemUserId,
+                                                              final List<DiscoverySchedulerConfiguration> activeCourtCentreConfigurations) {
+        final List<HearingCaseForDay> hearingCases = hearingClient.getHearingCasesForDay(hearingDate, cpSystemUserId.toString());
+        final List<HearingCaseForDay> matchedHearingCases = hearingCaseWhitelistSelector.findMatchingCases(hearingCases, activeCourtCentreConfigurations);
+        log.info("Nightly discovery matched hearingCases={} out of retrieved={} for hearingDate={}",
+                matchedHearingCases.size(), hearingCases.size(), hearingDate);
+        return matchedHearingCases;
+    }
+
+    private void dispatchCaseEligibilityCheck(final UUID caseId, final UUID cpSystemUserId) {
+        final JsonObject jobData = toJobDataForCaseEligibility(caseId, cpSystemUserId);
+        try {
+            jobManagerService.dispatchCaseDocumentIngestionTasksCheckCaseEligibility(jobData);
+        } catch (Exception e) {
+            log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
+        }
+    }
+
+    private static JsonObject toJobDataForCaseEligibility(final UUID caseId, final UUID cpSystemUserId) {
         return Json.createObjectBuilder()
                 .add(REQUEST_ID, randomUUID().toString())
                 .add(CPPUID, cpSystemUserId.toString())
@@ -124,14 +142,14 @@ public class DiscoveryService {
                 .build();
     }
 
-    private JsonObject toJobData(final String cppUid, final String courtCentreId,
-                                 final String roomId, final String date) {
+    private JsonObject toJobDataForGetCaseHearings(final String cppUid, final String courtCentreId,
+                                                   final String roomId, final String date) {
         return Json.createObjectBuilder()
-                .add("cppuid", cppUid)
-                .add("requestId", randomUUID().toString())
-                .add("courtCentreId", courtCentreId)
-                .add("roomId", roomId)
-                .add("date", date)
+                .add(CPPUID, cppUid)
+                .add(REQUEST_ID, randomUUID().toString())
+                .add(COURT_CENTRE_ID, courtCentreId)
+                .add(ROOM_ID, roomId)
+                .add(DATE, date)
                 .build();
     }
 

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelector.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelector.java
@@ -1,0 +1,47 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
+
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Filters hearing cases down to those whose court centre and courtroom are whitelisted
+ * by an active {@link DiscoverySchedulerConfiguration}.
+ */
+@Component
+public class HearingCaseWhitelistSelector {
+
+    @SuppressWarnings("PMD.OnlyOneReturn")
+    public List<HearingCaseForDay> findMatchingCases(final List<HearingCaseForDay> hearingCases,
+                                                     final List<DiscoverySchedulerConfiguration> activeCourtCentreConfigurations) {
+
+        if (isNull(hearingCases) || hearingCases.isEmpty()
+                || isNull(activeCourtCentreConfigurations) || activeCourtCentreConfigurations.isEmpty()) {
+            return emptyList();
+        }
+
+        final Set<CourtCentreRoom> whitelisted = activeCourtCentreConfigurations.stream()
+                .map(config -> new CourtCentreRoom(config.getCourtCentreId(), config.getCourtRoomId()))
+                .collect(Collectors.toSet());
+
+        return hearingCases.stream()
+                .filter(Objects::nonNull)
+                .filter(hearingCase -> whitelisted.contains(
+                        new CourtCentreRoom(hearingCase.courtCentreId(), hearingCase.courtRoomId())))
+                .distinct()
+                .toList();
+    }
+
+    private record CourtCentreRoom(UUID courtCentreId, UUID courtRoomId) {
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/JobManagerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/JobManagerService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cp.cdk.services;
 
+import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.CHECK_CASE_ELIGIBILITY;
 import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.GET_CASES_FOR_HEARING;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 
@@ -91,7 +92,7 @@ public class JobManagerService implements IngestionProcessor {
         }
 
         try {
-            dispatchCaseDocumentIngestionTasks(jobData);
+            dispatchCaseDocumentIngestionTasksGetCasesForHearing(jobData);
             log.info("Case ingestion process started via JobManager. requestId={}, cppuid={}", requestId, safeCppuid);
 
             response.setPhase(IngestionProcessPhase.STARTED);
@@ -113,9 +114,21 @@ public class JobManagerService implements IngestionProcessor {
     }
 
     /* package */
-    void dispatchCaseDocumentIngestionTasks(final JsonObject jobData) {
+    void dispatchCaseDocumentIngestionTasksGetCasesForHearing(final JsonObject jobData) {
         final ExecutionInfo executionInfo = executionInfo()
                 .withAssignedTaskName(GET_CASES_FOR_HEARING)
+                .withAssignedTaskStartTime(ZonedDateTime.now())
+                .withJobData(jobData)
+                .withExecutionStatus(ExecutionStatus.STARTED)
+                .build();
+
+        executor.executeWith(executionInfo);
+    }
+
+    /* package */
+    void dispatchCaseDocumentIngestionTasksCheckCaseEligibility(final JsonObject jobData) {
+        final ExecutionInfo executionInfo = executionInfo()
+                .withAssignedTaskName(CHECK_CASE_ELIGIBILITY)
                 .withAssignedTaskStartTime(ZonedDateTime.now())
                 .withJobData(jobData)
                 .withExecutionStatus(ExecutionStatus.STARTED)

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/JobManagerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/JobManagerService.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.cp.cdk.services;
 
-import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.CHECK_CASE_ELIGIBILITY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS;
 import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.GET_CASES_FOR_HEARING;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 
@@ -126,9 +126,9 @@ public class JobManagerService implements IngestionProcessor {
     }
 
     /* package */
-    void dispatchCaseDocumentIngestionTasksCheckCaseEligibility(final JsonObject jobData) {
+    void dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(final JsonObject jobData) {
         final ExecutionInfo executionInfo = executionInfo()
-                .withAssignedTaskName(CHECK_CASE_ELIGIBILITY)
+                .withAssignedTaskName(CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS)
                 .withAssignedTaskStartTime(ZonedDateTime.now())
                 .withJobData(jobData)
                 .withExecutionStatus(ExecutionStatus.STARTED)

--- a/src/main/java/uk/gov/hmcts/cp/cdk/util/EnvironmentUtil.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/util/EnvironmentUtil.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.cp.cdk.util;
+
+import static java.util.UUID.fromString;
+import static org.springframework.util.StringUtils.hasText;
+
+import java.util.UUID;
+
+import org.springframework.core.env.Environment;
+
+public class EnvironmentUtil {
+
+    private static final String CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID = "CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID";
+
+    public static UUID getSystemUserId(final Environment environment) {
+        final String configuredSystemUserId = environment.getProperty(CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID);
+        if (!hasText(configuredSystemUserId)) {
+            throw new IllegalStateException("Required environment variable '" + CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID + "' is not set.");
+        }
+
+        try {
+            return fromString(configuredSystemUserId);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException(
+                    "Environment variable '" + CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID + "' must contain a valid UUID, but was: '" + configuredSystemUserId + "'.", e);
+        }
+    }
+}

--- a/src/main/resources/application-clients.yml
+++ b/src/main/resources/application-clients.yml
@@ -21,8 +21,10 @@ cqrs:
     headers:
       cjs-cppuid: ${CP_CDK_CJSCPPUID_HEADER:CJSCPPUID}
     hearing:
-      accept-header: "application/vnd.hearing.get.hearings+json"
-      hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
+      get-hearings-accept-header: "application/vnd.hearing.get.hearings+json"
+      get-hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
+      get-hearing-cases-for-day-accept-header: "application/vnd.hearing.get.hearing-cases-for-day+json"
+      get-hearing-cases-for-day-path: "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day"
     progression:
       accept-header: "application/vnd.progression.query.courtdocuments+json"
       doc-type-id: "41be14e8-9df5-4b08-80b0-1e670bc80a5b"

--- a/src/test/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImplTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImplTest.java
@@ -9,6 +9,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import uk.gov.hmcts.cp.cdk.clients.common.CQRSClientProperties;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCasesForDayResponse;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummaries;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesInfo;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesListRequest;
@@ -16,6 +19,7 @@ import uk.gov.hmcts.cp.cdk.clients.hearing.mapper.HearingDtoMapper;
 
 import java.net.URI;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,13 +59,17 @@ class HearingClientImplTest {
     private final String acceptHeader = "application/json";
     private final String cppuidHeader = "cppuid";
     private final String hearingsPath = "/hearings";
+    private final String hearingCasesForDayAcceptHeader = "application/json";
+    private final String hearingCasesForDayPath = "/hearing-cases-for-day";
 
     @BeforeEach
     void setUp() {
         when(rootProps.headers()).thenReturn(headers);
         when(headers.cjsCppuid()).thenReturn(cppuidHeader);
-        when(hearingProps.acceptHeader()).thenReturn(acceptHeader);
-        when(hearingProps.hearingsPath()).thenReturn(hearingsPath);
+        when(hearingProps.getHearingsAcceptHeader()).thenReturn(acceptHeader);
+        when(hearingProps.getHearingsPath()).thenReturn(hearingsPath);
+        when(hearingProps.getHearingCasesForDayAcceptHeader()).thenReturn(hearingCasesForDayAcceptHeader);
+        when(hearingProps.getHearingCasesForDayPath()).thenReturn(hearingCasesForDayPath);
 
         client = new HearingClientImpl(restClient, rootProps, hearingProps, mapper);
     }
@@ -112,6 +120,44 @@ class HearingClientImplTest {
         when(responseSpec.body(HearingSummariesListRequest.class)).thenReturn(response);
 
         final List<HearingSummariesInfo> result = client.getHearingsAndCases("court", "room", now(), "user");
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldReturnHearingCases_whenValidResponse() {
+        final HearingCaseProsecutionCase prosecutionCase = new HearingCaseProsecutionCase(UUID.randomUUID());
+        final HearingCaseForDay hearingCase = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), now(), UUID.randomUUID(), List.of(prosecutionCase));
+        final HearingCasesForDayResponse response = new HearingCasesForDayResponse(List.of(hearingCase));
+
+        mockRestClient();
+        when(responseSpec.body(HearingCasesForDayResponse.class)).thenReturn(response);
+
+        final List<HearingCaseForDay> result = client.getHearingCasesForDay(now(), "user1");
+
+        assertThat(result).containsExactly(hearingCase);
+    }
+
+    @Test
+    void shouldReturnEmptyList_whenHearingCasesForDayResponseIsNull() {
+        mockRestClient();
+        when(responseSpec.body(HearingCasesForDayResponse.class)).thenReturn(null);
+
+        final List<HearingCaseForDay> result = client.getHearingCasesForDay(now(), "user");
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldReturnEmptyList_whenHearingCasesIsNull() {
+        final HearingCasesForDayResponse response = mock(HearingCasesForDayResponse.class);
+        when(response.hearingCases()).thenReturn(null);
+
+        mockRestClient();
+        when(responseSpec.body(HearingCasesForDayResponse.class)).thenReturn(response);
+
+        final List<HearingCaseForDay> result = client.getHearingCasesForDay(now(), "user");
 
         assertThat(result.isEmpty()).isTrue();
     }

--- a/src/test/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImplTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/clients/hearing/HearingClientImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 
 import uk.gov.hmcts.cp.cdk.clients.common.CQRSClientProperties;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
-import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCasesForDayResponse;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummaries;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingSummariesInfo;
@@ -126,9 +125,8 @@ class HearingClientImplTest {
 
     @Test
     void shouldReturnHearingCases_whenValidResponse() {
-        final HearingCaseProsecutionCase prosecutionCase = new HearingCaseProsecutionCase(UUID.randomUUID());
         final HearingCaseForDay hearingCase = new HearingCaseForDay(
-                UUID.randomUUID(), UUID.randomUUID(), now(), UUID.randomUUID(), List.of(prosecutionCase));
+                UUID.randomUUID(), UUID.randomUUID(), now(), UUID.randomUUID(), List.of(UUID.randomUUID()));
         final HearingCasesForDayResponse response = new HearingCasesForDayResponse(List.of(hearingCase));
 
         mockRestClient();

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
-import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 import uk.gov.hmcts.cp.cdk.domain.ScheduledIngestionRequest;
 import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
@@ -305,10 +304,10 @@ class DiscoveryServiceTest {
 
         final HearingCaseForDay morningHearing = new HearingCaseForDay(
                 UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+                List.of(sharedCaseId));
         final HearingCaseForDay afternoonHearing = new HearingCaseForDay(
                 UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+                List.of(sharedCaseId));
 
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today));
@@ -339,10 +338,10 @@ class DiscoveryServiceTest {
 
         final HearingCaseForDay caseToday = new HearingCaseForDay(
                 UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+                List.of(sharedCaseId));
         final HearingCaseForDay caseTomorrow = new HearingCaseForDay(
                 UUID.randomUUID(), UUID.randomUUID(), tomorrow, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+                List.of(sharedCaseId));
 
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today, tomorrow));
@@ -373,7 +372,7 @@ class DiscoveryServiceTest {
         final UUID caseId = UUID.randomUUID();
         final HearingCaseForDay matchedCase = new HearingCaseForDay(
                 UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(caseId)));
+                List.of(caseId));
 
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today));
@@ -544,9 +543,9 @@ class DiscoveryServiceTest {
     }
 
     private HearingCaseForDay hearingCaseWithProsecutionCases(final LocalDate hearingDate, final int prosecutionCaseCount) {
-        final List<HearingCaseProsecutionCase> prosecutionCases = new ArrayList<>();
+        final List<UUID> prosecutionCases = new ArrayList<>();
         for (int i = 0; i < prosecutionCaseCount; i++) {
-            prosecutionCases.add(new HearingCaseProsecutionCase(UUID.randomUUID()));
+            prosecutionCases.add(UUID.randomUUID());
         }
         return new HearingCaseForDay(UUID.randomUUID(), UUID.randomUUID(), hearingDate, UUID.randomUUID(), prosecutionCases);
     }

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
@@ -297,6 +297,75 @@ class DiscoveryServiceTest {
     }
 
     @Test
+    void runNightlyDiscovery_shouldDedupeSameCaseIdAppearingInMultipleMatchedHearingCasesOnSameDate() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final UUID sharedCaseId = UUID.randomUUID();
+
+        final HearingCaseForDay morningHearing = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+        final HearingCaseForDay afternoonHearing = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any()))
+                .thenReturn(List.of(morningHearing, afternoonHearing));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any()))
+                .thenReturn(List.of(morningHearing, afternoonHearing));
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
+        assertThat(captor.getValue().getString("caseId")).isEqualTo(sharedCaseId.toString());
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldDedupeSameCaseIdAppearingAcrossMultipleDates() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final LocalDate tomorrow = today.plusDays(1);
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final UUID sharedCaseId = UUID.randomUUID();
+
+        final HearingCaseForDay caseToday = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+        final HearingCaseForDay caseTomorrow = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), tomorrow, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(sharedCaseId)));
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today, tomorrow));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(eq(today), any())).thenReturn(List.of(caseToday));
+        when(hearingClient.getHearingCasesForDay(eq(tomorrow), any())).thenReturn(List.of(caseTomorrow));
+        when(hearingCaseWhitelistSelector.findMatchingCases(eq(List.of(caseToday)), any()))
+                .thenReturn(List.of(caseToday));
+        when(hearingCaseWhitelistSelector.findMatchingCases(eq(List.of(caseTomorrow)), any()))
+                .thenReturn(List.of(caseTomorrow));
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
+        assertThat(captor.getValue().getString("caseId")).isEqualTo(sharedCaseId.toString());
+    }
+
+    @Test
     void runNightlyDiscovery_shouldGenerateJobDataFromMatchedHearingCaseProsecutionCase() {
         // given
         final LocalDate today = LocalDate.now();

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
@@ -263,7 +263,7 @@ class DiscoveryServiceTest {
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any(JsonObject.class));
     }
 
     @Test
@@ -292,7 +292,7 @@ class DiscoveryServiceTest {
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, times(3)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+        verify(jobManagerService, times(3)).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any(JsonObject.class));
     }
 
     @Test
@@ -324,7 +324,7 @@ class DiscoveryServiceTest {
 
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
-        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
+        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(captor.capture());
         assertThat(captor.getValue().getString("caseId")).isEqualTo(sharedCaseId.toString());
     }
 
@@ -360,7 +360,7 @@ class DiscoveryServiceTest {
 
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
-        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
+        verify(jobManagerService, times(1)).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(captor.capture());
         assertThat(captor.getValue().getString("caseId")).isEqualTo(sharedCaseId.toString());
     }
 
@@ -387,7 +387,7 @@ class DiscoveryServiceTest {
 
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
-        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(captor.capture());
 
         final JsonObject jobData = captor.getValue();
         assertThat(jobData.getString("caseId")).isEqualTo(caseId.toString());
@@ -411,13 +411,13 @@ class DiscoveryServiceTest {
         when(hearingCaseWhitelistSelector.findMatchingCases(any(), any())).thenReturn(List.of(matchedCase));
         doThrow(new RuntimeException("Dispatch failed"))
                 .when(jobManagerService)
-                .dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+                .dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any(JsonObject.class));
 
         // when / then
         Assertions.assertThatCode(() -> discoveryService.runNightlyDiscovery())
                 .doesNotThrowAnyException();
 
-        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any(JsonObject.class));
     }
 
     @Test
@@ -441,7 +441,7 @@ class DiscoveryServiceTest {
         Assertions.assertThatCode(() -> discoveryService.runNightlyDiscovery())
                 .doesNotThrowAnyException();
 
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any());
     }
 
     @Test
@@ -464,7 +464,7 @@ class DiscoveryServiceTest {
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any());
     }
 
     @Test
@@ -482,7 +482,7 @@ class DiscoveryServiceTest {
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckIdpcAvailability(any());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.cp.cdk.services;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -10,6 +11,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import uk.gov.hmcts.cp.cdk.clients.hearing.HearingClient;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 import uk.gov.hmcts.cp.cdk.domain.ScheduledIngestionRequest;
 import uk.gov.hmcts.cp.cdk.repo.DiscoverySchedulerConfigurationRepository;
@@ -17,6 +21,7 @@ import uk.gov.hmcts.cp.cdk.repo.ScheduledIngestionRequestRepository;
 import uk.gov.hmcts.cp.cdk.scheduler.SchedulerProperties;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,6 +55,12 @@ class DiscoveryServiceTest {
     private HearingDaysCalculator hearingDaysCalculator;
 
     @Mock
+    private HearingClient hearingClient;
+
+    @Mock
+    private HearingCaseWhitelistSelector hearingCaseWhitelistSelector;
+
+    @Mock
     private Environment environment;
 
     private DiscoveryService discoveryService;
@@ -60,7 +71,7 @@ class DiscoveryServiceTest {
         schedulerProperties.getNightlyDiscovery().setDaysAhead(NIGHTLY_DISCOVERY_DAYS);
         discoveryService = new DiscoveryService(
                 jobManagerService, scheduledIngestionRequestRepository, discoverySchedulerConfigurationRepository,
-                hearingDaysCalculator, schedulerProperties, environment);
+                hearingDaysCalculator, hearingClient, hearingCaseWhitelistSelector, schedulerProperties, environment);
     }
 
     @Test
@@ -79,7 +90,7 @@ class DiscoveryServiceTest {
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
 
-        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasks(captor.capture());
+        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasksGetCasesForHearing(captor.capture());
 
         final List<JsonObject> captured = captor.getAllValues();
         assertThat(captured).hasSize(2);
@@ -101,14 +112,14 @@ class DiscoveryServiceTest {
 
         doThrow(new RuntimeException("Dispatch failed"))
                 .when(jobManagerService)
-                .dispatchCaseDocumentIngestionTasks(any(JsonObject.class));
+                .dispatchCaseDocumentIngestionTasksGetCasesForHearing(any(JsonObject.class));
 
         // when
         Assertions.assertThatCode(() -> discoveryService.runIntradayDiscovery())
                 .doesNotThrowAnyException();
 
         // then
-        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasks(any(JsonObject.class));
+        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasksGetCasesForHearing(any(JsonObject.class));
     }
 
     @Test
@@ -123,7 +134,7 @@ class DiscoveryServiceTest {
         discoveryService.runIntradayDiscovery();
 
         // then
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasks(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksGetCasesForHearing(any());
 
         verify(scheduledIngestionRequestRepository, times(1))
                 .findAllByHearingDate(today);
@@ -152,7 +163,7 @@ class DiscoveryServiceTest {
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
 
-        verify(jobManagerService).dispatchCaseDocumentIngestionTasks(captor.capture());
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksGetCasesForHearing(captor.capture());
 
         final JsonObject jobData = captor.getValue();
         assertThat(jobData.getString("cppuid")).isEqualTo(cppuid.toString());
@@ -195,55 +206,125 @@ class DiscoveryServiceTest {
     }
 
     @Test
-    void runNightlyDiscovery_shouldDispatchTasksForEveryConfigurationAndCalculatedDate() {
+    void runNightlyDiscovery_shouldRetrieveHearingCasesForEachCalculatedDateUsingSystemUser() {
         // given
         final LocalDate today = LocalDate.now();
         final LocalDate tomorrow = today.plusDays(1);
 
-        final DiscoverySchedulerConfiguration config1 = mockConfiguration();
-        final DiscoverySchedulerConfiguration config2 = mockConfiguration();
-
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today, tomorrow));
-        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
-                .thenReturn(List.of(config1, config2));
         when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
 
         // when
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, times(4)).dispatchCaseDocumentIngestionTasks(any(JsonObject.class));
+        verify(hearingClient).getHearingCasesForDay(today, SYSTEM_USER_ID);
+        verify(hearingClient).getHearingCasesForDay(tomorrow, SYSTEM_USER_ID);
     }
 
     @Test
-    void runNightlyDiscovery_shouldGenerateJobDataFromConfigurationAndHearingDate() {
+    void runNightlyDiscovery_shouldFilterRetrievedHearingCasesUsingWhitelistSelector() {
         // given
         final LocalDate today = LocalDate.now();
-        final UUID courtCentreId = UUID.randomUUID();
-        final UUID courtRoomId = UUID.randomUUID();
-        final DiscoverySchedulerConfiguration config = mockConfiguration(courtCentreId, courtRoomId);
-        final String mockedCppuid = UUID.randomUUID().toString();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final List<DiscoverySchedulerConfiguration> configs = List.of(config);
+        final List<HearingCaseForDay> retrievedCases = List.of(hearingCaseWithProsecutionCases(today, 0));
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(configs);
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(today, SYSTEM_USER_ID)).thenReturn(retrievedCases);
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        verify(hearingCaseWhitelistSelector).findMatchingCases(retrievedCases, configs);
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldDispatchCheckCaseEligibilityTaskForEachProsecutionCaseInMatchedHearingCases() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final HearingCaseForDay matchedCase = hearingCaseWithProsecutionCases(today, 2);
 
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today));
         when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
                 .thenReturn(List.of(config));
-        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(mockedCppuid);
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any())).thenReturn(List.of(matchedCase));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any())).thenReturn(List.of(matchedCase));
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        verify(jobManagerService, times(2)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldDispatchAcrossMultipleDatesAndMatchedHearingCases() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final LocalDate tomorrow = today.plusDays(1);
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+
+        final HearingCaseForDay caseToday = hearingCaseWithProsecutionCases(today, 2);
+        final HearingCaseForDay caseTomorrow = hearingCaseWithProsecutionCases(tomorrow, 1);
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today, tomorrow));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(eq(today), any())).thenReturn(List.of(caseToday));
+        when(hearingClient.getHearingCasesForDay(eq(tomorrow), any())).thenReturn(List.of(caseTomorrow));
+        when(hearingCaseWhitelistSelector.findMatchingCases(eq(List.of(caseToday)), any()))
+                .thenReturn(List.of(caseToday));
+        when(hearingCaseWhitelistSelector.findMatchingCases(eq(List.of(caseTomorrow)), any()))
+                .thenReturn(List.of(caseTomorrow));
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        verify(jobManagerService, times(3)).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldGenerateJobDataFromMatchedHearingCaseProsecutionCase() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final UUID caseId = UUID.randomUUID();
+        final HearingCaseForDay matchedCase = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(caseId)));
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any())).thenReturn(List.of(matchedCase));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any())).thenReturn(List.of(matchedCase));
 
         // when
         discoveryService.runNightlyDiscovery();
 
         // then
         final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
-        verify(jobManagerService).dispatchCaseDocumentIngestionTasks(captor.capture());
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(captor.capture());
 
         final JsonObject jobData = captor.getValue();
-        assertThat(jobData.getString("courtCentreId")).isEqualTo(courtCentreId.toString());
-        assertThat(jobData.getString("roomId")).isEqualTo(courtRoomId.toString());
-        assertThat(jobData.getString("date")).isEqualTo(today.toString());
+        assertThat(jobData.getString("caseId")).isEqualTo(caseId.toString());
+        assertThat(jobData.getString("cppuid")).isEqualTo(SYSTEM_USER_ID);
         assertThat(jobData.getString("requestId")).isNotBlank();
-        assertThat(jobData.getString("cppuid")).isEqualTo(mockedCppuid);
     }
 
     @Test
@@ -251,21 +332,71 @@ class DiscoveryServiceTest {
         // given
         final LocalDate today = LocalDate.now();
         final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final HearingCaseForDay matchedCase = hearingCaseWithProsecutionCases(today, 1);
 
         when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
                 .thenReturn(List.of(today));
         when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
                 .thenReturn(List.of(config));
         when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any())).thenReturn(List.of(matchedCase));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any())).thenReturn(List.of(matchedCase));
         doThrow(new RuntimeException("Dispatch failed"))
                 .when(jobManagerService)
-                .dispatchCaseDocumentIngestionTasks(any(JsonObject.class));
+                .dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
 
         // when / then
         Assertions.assertThatCode(() -> discoveryService.runNightlyDiscovery())
                 .doesNotThrowAnyException();
 
-        verify(jobManagerService).dispatchCaseDocumentIngestionTasks(any(JsonObject.class));
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any(JsonObject.class));
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldNotDispatchWhenMatchedHearingCaseHasNullProsecutionCases() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final HearingCaseForDay matchedCaseWithoutProsecutionCases = new HearingCaseForDay(
+                UUID.randomUUID(), UUID.randomUUID(), today, UUID.randomUUID(), null);
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any())).thenReturn(List.of(matchedCaseWithoutProsecutionCases));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any()))
+                .thenReturn(List.of(matchedCaseWithoutProsecutionCases));
+
+        // when / then
+        Assertions.assertThatCode(() -> discoveryService.runNightlyDiscovery())
+                .doesNotThrowAnyException();
+
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldNotDispatchWhenMatchedHearingCaseHasEmptyProsecutionCases() {
+        // given
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration();
+        final HearingCaseForDay matchedCaseWithEmptyProsecutionCases = hearingCaseWithProsecutionCases(today, 0);
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        when(hearingClient.getHearingCasesForDay(any(), any())).thenReturn(List.of(matchedCaseWithEmptyProsecutionCases));
+        when(hearingCaseWhitelistSelector.findMatchingCases(any(), any()))
+                .thenReturn(List.of(matchedCaseWithEmptyProsecutionCases));
+
+        // when
+        discoveryService.runNightlyDiscovery();
+
+        // then
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
     }
 
     @Test
@@ -283,7 +414,7 @@ class DiscoveryServiceTest {
         discoveryService.runNightlyDiscovery();
 
         // then
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasks(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksCheckCaseEligibility(any());
     }
 
     @Test
@@ -301,7 +432,7 @@ class DiscoveryServiceTest {
         Assertions.assertThatCode(() -> discoveryService.runNightlyDiscovery())
                 .doesNotThrowAnyException();
 
-        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasks(any());
+        verify(jobManagerService, never()).dispatchCaseDocumentIngestionTasksGetCasesForHearing(any());
     }
 
     @Test
@@ -340,14 +471,15 @@ class DiscoveryServiceTest {
     }
 
     private DiscoverySchedulerConfiguration mockConfiguration() {
-        return mockConfiguration(UUID.randomUUID(), UUID.randomUUID());
+        return mock(DiscoverySchedulerConfiguration.class);
     }
 
-    private DiscoverySchedulerConfiguration mockConfiguration(final UUID courtCentreId, final UUID courtRoomId) {
-        final DiscoverySchedulerConfiguration configuration = mock(DiscoverySchedulerConfiguration.class);
-        when(configuration.getCourtCentreId()).thenReturn(courtCentreId);
-        when(configuration.getCourtRoomId()).thenReturn(courtRoomId);
-        return configuration;
+    private HearingCaseForDay hearingCaseWithProsecutionCases(final LocalDate hearingDate, final int prosecutionCaseCount) {
+        final List<HearingCaseProsecutionCase> prosecutionCases = new ArrayList<>();
+        for (int i = 0; i < prosecutionCaseCount; i++) {
+            prosecutionCases.add(new HearingCaseProsecutionCase(UUID.randomUUID()));
+        }
+        return new HearingCaseForDay(UUID.randomUUID(), UUID.randomUUID(), hearingDate, UUID.randomUUID(), prosecutionCases);
     }
 
     private ScheduledIngestionRequest mockRequest() {

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelectorTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelectorTest.java
@@ -1,0 +1,193 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
+import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
+import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("HearingCaseWhitelistSelector tests")
+class HearingCaseWhitelistSelectorTest {
+
+    private static final LocalDate HEARING_DATE = LocalDate.of(2026, 7, 13);
+
+    private HearingCaseWhitelistSelector selector;
+
+    @BeforeEach
+    void setUp() {
+        selector = new HearingCaseWhitelistSelector();
+    }
+
+    @Test
+    @DisplayName("Returns the case when both courtCentreId and courtRoomId match an active configuration")
+    void findMatchingCases_returnsCase_whenCentreAndRoomMatchConfiguration() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final HearingCaseForDay hearingCase = hearingCase(courtCentreId, courtRoomId);
+        final DiscoverySchedulerConfiguration configuration = configuration(courtCentreId, courtRoomId);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(hearingCase), List.of(configuration));
+
+        assertThat(result).containsExactly(hearingCase);
+    }
+
+    @Test
+    @DisplayName("Filters out the case when courtRoomId does not match, even though courtCentreId matches")
+    void findMatchingCases_excludesCase_whenRoomDoesNotMatch() {
+        final UUID courtCentreId = UUID.randomUUID();
+
+        final HearingCaseForDay hearingCase = hearingCase(courtCentreId, UUID.randomUUID());
+        final DiscoverySchedulerConfiguration configuration = configuration(courtCentreId, UUID.randomUUID());
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(hearingCase), List.of(configuration));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Filters out the case when courtCentreId does not match, even though courtRoomId matches")
+    void findMatchingCases_excludesCase_whenCentreDoesNotMatch() {
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final HearingCaseForDay hearingCase = hearingCase(UUID.randomUUID(), courtRoomId);
+        final DiscoverySchedulerConfiguration configuration = configuration(UUID.randomUUID(), courtRoomId);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(hearingCase), List.of(configuration));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Does not match a case whose centre and room each belong to a different configuration")
+    void findMatchingCases_excludesCase_whenCentreAndRoomComeFromDifferentConfigurations() {
+        final UUID centreA = UUID.randomUUID();
+        final UUID roomA = UUID.randomUUID();
+        final UUID centreB = UUID.randomUUID();
+        final UUID roomB = UUID.randomUUID();
+
+        // hearing case pairs centreA with roomB - neither whitelisted configuration has this exact pair
+        final HearingCaseForDay hearingCase = hearingCase(centreA, roomB);
+        final DiscoverySchedulerConfiguration configurationA = configuration(centreA, roomA);
+        final DiscoverySchedulerConfiguration configurationB = configuration(centreB, roomB);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(
+                List.of(hearingCase), List.of(configurationA, configurationB));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Returns only the matching subset when multiple cases and configurations are provided")
+    void findMatchingCases_returnsOnlyMatchedSubset_whenMultipleCasesAndConfigurationsProvided() {
+        final UUID centre1 = UUID.randomUUID();
+        final UUID room1 = UUID.randomUUID();
+        final UUID centre2 = UUID.randomUUID();
+        final UUID room2 = UUID.randomUUID();
+
+        final HearingCaseForDay matchedCase1 = hearingCase(centre1, room1);
+        final HearingCaseForDay matchedCase2 = hearingCase(centre2, room2);
+        final HearingCaseForDay unmatchedCase = hearingCase(UUID.randomUUID(), UUID.randomUUID());
+
+        final DiscoverySchedulerConfiguration configuration1 = configuration(centre1, room1);
+        final DiscoverySchedulerConfiguration configuration2 = configuration(centre2, room2);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(
+                Arrays.asList(matchedCase1, unmatchedCase, matchedCase2),
+                List.of(configuration1, configuration2));
+
+        assertThat(result).containsExactlyInAnyOrder(matchedCase1, matchedCase2);
+    }
+
+    @Test
+    @DisplayName("Deduplicates identical hearing cases appearing more than once in the input")
+    void findMatchingCases_deduplicatesIdenticalCases() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final HearingCaseForDay hearingCase = hearingCase(courtCentreId, courtRoomId);
+        final DiscoverySchedulerConfiguration configuration = configuration(courtCentreId, courtRoomId);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(
+                List.of(hearingCase, hearingCase), List.of(configuration));
+
+        assertThat(result).containsExactly(hearingCase);
+    }
+
+    @Test
+    @DisplayName("Skips null elements within the hearing cases list instead of throwing")
+    void findMatchingCases_skipsNullElements() {
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+
+        final HearingCaseForDay hearingCase = hearingCase(courtCentreId, courtRoomId);
+        final DiscoverySchedulerConfiguration configuration = configuration(courtCentreId, courtRoomId);
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(
+                Arrays.asList(null, hearingCase), List.of(configuration));
+
+        assertThat(result).containsExactly(hearingCase);
+    }
+
+    @Test
+    @DisplayName("Returns an empty list when hearingCases is null")
+    void findMatchingCases_returnsEmpty_whenHearingCasesIsNull() {
+        final DiscoverySchedulerConfiguration configuration = configuration(UUID.randomUUID(), UUID.randomUUID());
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(null, List.of(configuration));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Returns an empty list when hearingCases is empty")
+    void findMatchingCases_returnsEmpty_whenHearingCasesIsEmpty() {
+        final DiscoverySchedulerConfiguration configuration = configuration(UUID.randomUUID(), UUID.randomUUID());
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(), List.of(configuration));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Returns an empty list when activeCourtCentreConfigurations is null")
+    void findMatchingCases_returnsEmpty_whenConfigurationsIsNull() {
+        final HearingCaseForDay hearingCase = hearingCase(UUID.randomUUID(), UUID.randomUUID());
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(hearingCase), null);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Returns an empty list when activeCourtCentreConfigurations is empty")
+    void findMatchingCases_returnsEmpty_whenConfigurationsIsEmpty() {
+        final HearingCaseForDay hearingCase = hearingCase(UUID.randomUUID(), UUID.randomUUID());
+
+        final List<HearingCaseForDay> result = selector.findMatchingCases(List.of(hearingCase), List.of());
+
+        assertThat(result).isEmpty();
+    }
+
+    private HearingCaseForDay hearingCase(final UUID courtCentreId, final UUID courtRoomId) {
+        return new HearingCaseForDay(
+                courtCentreId, courtRoomId, HEARING_DATE, UUID.randomUUID(),
+                List.of(new HearingCaseProsecutionCase(UUID.randomUUID())));
+    }
+
+    private DiscoverySchedulerConfiguration configuration(final UUID courtCentreId, final UUID courtRoomId) {
+        final DiscoverySchedulerConfiguration configuration = new DiscoverySchedulerConfiguration();
+        configuration.setCourtCentreId(courtCentreId);
+        configuration.setCourtRoomId(courtRoomId);
+        return configuration;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelectorTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/HearingCaseWhitelistSelectorTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.cp.cdk.services;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseForDay;
-import uk.gov.hmcts.cp.cdk.clients.hearing.dto.HearingCaseProsecutionCase;
 import uk.gov.hmcts.cp.cdk.domain.DiscoverySchedulerConfiguration;
 
 import java.time.LocalDate;
@@ -181,7 +180,7 @@ class HearingCaseWhitelistSelectorTest {
     private HearingCaseForDay hearingCase(final UUID courtCentreId, final UUID courtRoomId) {
         return new HearingCaseForDay(
                 courtCentreId, courtRoomId, HEARING_DATE, UUID.randomUUID(),
-                List.of(new HearingCaseProsecutionCase(UUID.randomUUID())));
+                List.of(UUID.randomUUID()));
     }
 
     private DiscoverySchedulerConfiguration configuration(final UUID courtCentreId, final UUID courtRoomId) {

--- a/src/test/java/uk/gov/hmcts/cp/cdk/util/EnvironmentUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/util/EnvironmentUtilTest.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.cp.cdk.util;
+
+import static java.util.UUID.randomUUID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.cp.cdk.util.EnvironmentUtil.getSystemUserId;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class EnvironmentUtilTest {
+
+    private static final String PROPERTY_NAME = "CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID";
+
+    @Mock
+    private Environment environment;
+
+    @Test
+    void shouldReturnSystemUserIdWhenEnvironmentVariableContainsValidUuid() {
+
+        final UUID expected = randomUUID();
+        when(environment.getProperty(PROPERTY_NAME)).thenReturn(expected.toString());
+
+        final UUID actual = getSystemUserId(environment);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnvironmentVariableIsMissing() {
+
+        when(environment.getProperty(PROPERTY_NAME)).thenReturn(null);
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> getSystemUserId(environment));
+        assertEquals(
+                "Required environment variable 'CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID' is not set.",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnvironmentVariableIsBlank() {
+        when(environment.getProperty(PROPERTY_NAME)).thenReturn("   ");
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> EnvironmentUtil.getSystemUserId(environment));
+        assertEquals(
+                "Required environment variable 'CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID' is not set.",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEnvironmentVariableIsNotValidUuid() {
+        when(environment.getProperty(PROPERTY_NAME)).thenReturn("not-a-uuid");
+
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> EnvironmentUtil.getSystemUserId(environment));
+        assertEquals(
+                "Environment variable 'CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID' must contain a valid UUID, but was: 'not-a-uuid'.",
+                exception.getMessage());
+    }
+}


### PR DESCRIPTION
**What**

   Nightly discovery now fetches hearing cases per calculated date, whitelist-filters them against active court-centre/room configs, dedupes prosecution case IDs across the whole run, and for each unique case
  dispatches straight to CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS (previously it went through a CHECK_CASE_ELIGIBILITY hop, since removed).

  **Changes**

    Production code
  - HearingCaseForDay.prosecutionCases — List<UUID> (was List<HearingCaseProsecutionCase>); the wrapper record HearingCaseProsecutionCase was deleted.
  - HearingClient/HearingClientImpl — new getHearingCasesForDay(date, userId); HearingClientConfig split into get-hearings-* and get-hearing-cases-for-day-* properties (breaking config rename,
  application-clients.yml updated).
  - HearingCaseWhitelistSelector (new) — filters hearing cases by exact (courtCentreId, courtRoomId) match against active configs; null-safe, dedupes identical entries.
  - DiscoveryService.runNightlyDiscovery() — aggregates matched hearing cases across all calculated dates, dedupes caseIds via LinkedHashSet<UUID>, dispatches
  dispatchCaseDocumentIngestionTasksCheckIdpcAvailability once per unique case. getSystemUserId extracted out to a new EnvironmentUtil (shared, testable in isolation — EnvironmentUtilTest added).
  - JobManagerService — single dispatch method split into dispatchCaseDocumentIngestionTasksGetCasesForHearing (intraday/ingestion-process) and dispatchCaseDocumentIngestionTasksCheckIdpcAvailability (nightly,
  dispatches CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS directly — the CHECK_CASE_ELIGIBILITY dispatch method that existed briefly is gone).

  Tests
  - DiscoveryServiceTest — expanded (~264 lines): per-date fetch, whitelist invocation, per-case dispatch, same-day/cross-date dedup, null/empty prosecution-case handling, failure resilience — all asserting
  against dispatchCaseDocumentIngestionTasksCheckIdpcAvailability.
  - HearingCaseWhitelistSelectorTest, HearingClientImplTest — updated for the List<UUID> DTO shape.
  - EnvironmentUtilTest (new) — covers missing/invalid system-user-id env var.
  - NightlyDiscoverySchedulerLiveTest + ProgressionQueryApiStub — now stub/assert courtdocumentsearch?caseId=... returning empty documentIndices (replacing the earlier prosecution-case-eligibility
  stub/assertion), matching the new dispatch target end-to-end.