### PR TITLE
[DD-42959] Add a toggle to the /hearing-cases-for-day endpoint until this is available

### DIFF
--- a/docker/docker-compose.integration.yml
+++ b/docker/docker-compose.integration.yml
@@ -176,6 +176,7 @@ services:
       CP_CDK_BASE_URL: http://wiremock:8080
       CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED: true
       CASEDOCUMENTKNOWLEDGE_SYSTEM_USER_ID: "00000000-0000-0000-0000-000000000001"
+      CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED: true
 
     healthcheck:
       test: [ "CMD-SHELL", "curl -fsS http://localhost:8082/casedocumentknowledge-service/actuator/health || exit 1" ]

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryService.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +44,7 @@ public class DiscoveryService {
     private final HearingCaseWhitelistSelector hearingCaseWhitelistSelector;
     private final SchedulerProperties schedulerProperties;
     private final Environment environment;
+    private final boolean isHearingForCasesEnabled;
 
     public DiscoveryService(final JobManagerService jobManagerService,
                             final ScheduledIngestionRequestRepository scheduledIngestionRequestRepository,
@@ -51,7 +53,8 @@ public class DiscoveryService {
                             final HearingClient hearingClient,
                             final HearingCaseWhitelistSelector hearingCaseWhitelistSelector,
                             final SchedulerProperties schedulerProperties,
-                            final Environment environment) {
+                            final Environment environment,
+                            @Value("${cqrs.client.hearing.is-hearing-for-cases-enabled:false}") final boolean isHearingForCasesEnabled) {
         this.jobManagerService = jobManagerService;
         this.scheduledIngestionRequestRepository = scheduledIngestionRequestRepository;
         this.discoverySchedulerConfigurationRepository = discoverySchedulerConfigurationRepository;
@@ -60,6 +63,7 @@ public class DiscoveryService {
         this.hearingCaseWhitelistSelector = hearingCaseWhitelistSelector;
         this.schedulerProperties = schedulerProperties;
         this.environment = environment;
+        this.isHearingForCasesEnabled = isHearingForCasesEnabled;
     }
 
     /**
@@ -96,19 +100,34 @@ public class DiscoveryService {
         log.info("Nightly discovery for active courtCentre configurations={} is made using the CPP SystemUser={}",
                 activeCourtCentreConfigurations.size(), cpSystemUserId);
 
-        final List<HearingCaseForDay> matchedHearingCases = hearingDates.stream()
-                .flatMap(hearingDate -> matchHearingCasesForDate(hearingDate, cpSystemUserId, activeCourtCentreConfigurations).stream())
-                .toList();
+        if (isHearingForCasesEnabled) {
+            final List<HearingCaseForDay> matchedHearingCases = hearingDates.stream()
+                    .flatMap(hearingDate -> matchHearingCasesForDate(hearingDate, cpSystemUserId, activeCourtCentreConfigurations).stream())
+                    .toList();
 
-        final Set<UUID> uniqueCaseIds = matchedHearingCases.stream()
-                .filter(hearingCase -> nonNull(hearingCase.prosecutionCases()))
-                .flatMap(hearingCase -> hearingCase.prosecutionCases().stream())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+            final Set<UUID> uniqueCaseIds = matchedHearingCases.stream()
+                    .filter(hearingCase -> nonNull(hearingCase.prosecutionCases()))
+                    .flatMap(hearingCase -> hearingCase.prosecutionCases().stream())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
 
-        log.info("Nightly discovery dispatching case eligibility checks for uniqueCaseIds={} out of matchedHearingCases={}",
-                uniqueCaseIds.size(), matchedHearingCases.size());
+            log.info("Nightly discovery dispatching case eligibility checks for uniqueCaseIds={} out of matchedHearingCases={}",
+                    uniqueCaseIds.size(), matchedHearingCases.size());
 
-        uniqueCaseIds.forEach(caseId -> dispatchCaseEligibilityCheck(caseId, cpSystemUserId));
+            uniqueCaseIds.forEach(caseId -> dispatchCaseEligibilityCheck(caseId, cpSystemUserId));
+        } else {
+            activeCourtCentreConfigurations.forEach(acc -> {
+                hearingDates.stream()
+                        .map(hd -> toJobDataForGetCaseHearings(cpSystemUserId.toString(), acc.getCourtCentreId().toString(),
+                                acc.getCourtRoomId().toString(), hd.toString()))
+                        .forEach(jobData -> {
+                            try {
+                                jobManagerService.dispatchCaseDocumentIngestionTasksGetCasesForHearing(jobData);
+                            } catch (Exception e) {
+                                log.error("Nightly Discovery - Failed to dispatch case ingestion tasks for the jobData={}", jobData, e);
+                            }
+                        });
+            });
+        }
     }
 
     private List<HearingCaseForDay> matchHearingCasesForDate(final LocalDate hearingDate, final UUID cpSystemUserId,

--- a/src/main/resources/application-clients.yml
+++ b/src/main/resources/application-clients.yml
@@ -25,6 +25,7 @@ cqrs:
       get-hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
       get-hearing-cases-for-day-accept-header: "application/vnd.hearing.get.hearing-cases-for-day+json"
       get-hearing-cases-for-day-path: "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day"
+      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:false}
     progression:
       accept-header: "application/vnd.progression.query.courtdocuments+json"
       doc-type-id: "41be14e8-9df5-4b08-80b0-1e670bc80a5b"

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryServiceTest.java
@@ -66,11 +66,7 @@ class DiscoveryServiceTest {
 
     @BeforeEach
     void setUp() {
-        final SchedulerProperties schedulerProperties = new SchedulerProperties();
-        schedulerProperties.getNightlyDiscovery().setDaysAhead(NIGHTLY_DISCOVERY_DAYS);
-        discoveryService = new DiscoveryService(
-                jobManagerService, scheduledIngestionRequestRepository, discoverySchedulerConfigurationRepository,
-                hearingDaysCalculator, hearingClient, hearingCaseWhitelistSelector, schedulerProperties, environment);
+        discoveryService = discoveryServiceWithHearingForCasesEnabled(true);
     }
 
     @Test
@@ -504,6 +500,83 @@ class DiscoveryServiceTest {
     }
 
     @Test
+    void runNightlyDiscovery_shouldDispatchLegacyTaskForEveryConfigurationAndCalculatedDate_whenHearingForCasesDisabled() {
+        // given
+        final DiscoveryService legacyDiscoveryService = discoveryServiceWithHearingForCasesEnabled(false);
+        final LocalDate today = LocalDate.now();
+        final LocalDate tomorrow = today.plusDays(1);
+
+        final DiscoverySchedulerConfiguration config1 = mockConfiguration(UUID.randomUUID(), UUID.randomUUID());
+        final DiscoverySchedulerConfiguration config2 = mockConfiguration(UUID.randomUUID(), UUID.randomUUID());
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today, tomorrow));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config1, config2));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+
+        // when
+        legacyDiscoveryService.runNightlyDiscovery();
+
+        // then
+        verify(jobManagerService, times(4)).dispatchCaseDocumentIngestionTasksGetCasesForHearing(any(JsonObject.class));
+        verifyNoInteractions(hearingClient, hearingCaseWhitelistSelector);
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldGenerateLegacyJobDataFromConfigurationAndHearingDate_whenHearingForCasesDisabled() {
+        // given
+        final DiscoveryService legacyDiscoveryService = discoveryServiceWithHearingForCasesEnabled(false);
+        final LocalDate today = LocalDate.now();
+        final UUID courtCentreId = UUID.randomUUID();
+        final UUID courtRoomId = UUID.randomUUID();
+        final DiscoverySchedulerConfiguration config = mockConfiguration(courtCentreId, courtRoomId);
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+
+        // when
+        legacyDiscoveryService.runNightlyDiscovery();
+
+        // then
+        final ArgumentCaptor<JsonObject> captor = ArgumentCaptor.forClass(JsonObject.class);
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksGetCasesForHearing(captor.capture());
+
+        final JsonObject jobData = captor.getValue();
+        assertThat(jobData.getString("courtCentreId")).isEqualTo(courtCentreId.toString());
+        assertThat(jobData.getString("roomId")).isEqualTo(courtRoomId.toString());
+        assertThat(jobData.getString("date")).isEqualTo(today.toString());
+        assertThat(jobData.getString("requestId")).isNotBlank();
+        assertThat(jobData.getString("cppuid")).isEqualTo(SYSTEM_USER_ID);
+    }
+
+    @Test
+    void runNightlyDiscovery_shouldContinueWhenLegacyDispatchFails_whenHearingForCasesDisabled() {
+        // given
+        final DiscoveryService legacyDiscoveryService = discoveryServiceWithHearingForCasesEnabled(false);
+        final LocalDate today = LocalDate.now();
+        final DiscoverySchedulerConfiguration config = mockConfiguration(UUID.randomUUID(), UUID.randomUUID());
+
+        when(hearingDaysCalculator.calculate(today, NIGHTLY_DISCOVERY_DAYS))
+                .thenReturn(List.of(today));
+        when(discoverySchedulerConfigurationRepository.findLatestActiveConfigurations())
+                .thenReturn(List.of(config));
+        when(environment.getProperty(SYSTEM_USER_ID_ENV_KEY)).thenReturn(SYSTEM_USER_ID);
+        doThrow(new RuntimeException("Dispatch failed"))
+                .when(jobManagerService)
+                .dispatchCaseDocumentIngestionTasksGetCasesForHearing(any(JsonObject.class));
+
+        // when / then
+        Assertions.assertThatCode(() -> legacyDiscoveryService.runNightlyDiscovery())
+                .doesNotThrowAnyException();
+
+        verify(jobManagerService).dispatchCaseDocumentIngestionTasksGetCasesForHearing(any(JsonObject.class));
+    }
+
+    @Test
     void runNightlyDiscovery_shouldThrowIllegalStateExceptionWhenSystemUserIdEnvVarIsMissing() {
         // given
         final LocalDate today = LocalDate.now();
@@ -538,8 +611,24 @@ class DiscoveryServiceTest {
         verifyNoInteractions(jobManagerService);
     }
 
+    private DiscoveryService discoveryServiceWithHearingForCasesEnabled(final boolean isHearingForCasesEnabled) {
+        final SchedulerProperties schedulerProperties = new SchedulerProperties();
+        schedulerProperties.getNightlyDiscovery().setDaysAhead(NIGHTLY_DISCOVERY_DAYS);
+        return new DiscoveryService(
+                jobManagerService, scheduledIngestionRequestRepository, discoverySchedulerConfigurationRepository,
+                hearingDaysCalculator, hearingClient, hearingCaseWhitelistSelector, schedulerProperties, environment,
+                isHearingForCasesEnabled);
+    }
+
     private DiscoverySchedulerConfiguration mockConfiguration() {
         return mock(DiscoverySchedulerConfiguration.class);
+    }
+
+    private DiscoverySchedulerConfiguration mockConfiguration(final UUID courtCentreId, final UUID courtRoomId) {
+        final DiscoverySchedulerConfiguration configuration = mock(DiscoverySchedulerConfiguration.class);
+        when(configuration.getCourtCentreId()).thenReturn(courtCentreId);
+        when(configuration.getCourtRoomId()).thenReturn(courtRoomId);
+        return configuration;
     }
 
     private HearingCaseForDay hearingCaseWithProsecutionCases(final LocalDate hearingDate, final int prosecutionCaseCount) {


### PR DESCRIPTION
  **What**

  Added a feature flag, isHearingForCasesEnabled, that switches DiscoveryService.runNightlyDiscovery() between the new hearing-cases-for-day/whitelist/dedup flow (just merged via PR #196) and the original per-config/per-date dispatch it replaced.

  **Why**

  A safe rollback lever for the newly-merged nightly-discovery rework — if the new hearing-cases-for-day integration misbehaves in an environment, ops can flip back to the old dispatch behavior via config/env
  var without a code revert. Defaults to false (legacy behavior) everywhere except the integration-test compose stack, where it's forced true so NightlyDiscoverySchedulerLiveTest keeps exercising the new flow
  it already asserts against.

  **Changes**

  - application-clients.yml — new property cqrs.client.hearing.is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:false}.
  - docker-compose.integration.yml — sets CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED: true for the app container used by gradle integration.
  - DiscoveryService.java — new constructor param isHearingForCasesEnabled (via @Value, constructor-injected). runNightlyDiscovery() now branches: enabled → existing
  fetch/whitelist-match/dedupe/CHECK_IDPC_AVAILABILITY_ALL_DEFENDANTS flow; disabled → legacy per-config×per-date GET_CASES_FOR_HEARING dispatch, no hearingClient/hearingCaseWhitelistSelector interaction.
  - DiscoveryServiceTest.java — construction refactored through a discoveryServiceWithHearingForCasesEnabled(boolean) helper; existing tests now explicitly run with the flag true; three new tests cover the
  disabled/legacy path (per-config×date dispatch count, job-data shape, continue-on-dispatch-failure).