### PR TITLE
Fix: by-case ingestion incorrectly returns NOT_REQUIRED without a generated answer

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/IngestionProcessByCaseHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/IngestionProcessByCaseHttpLiveTest.java
@@ -26,10 +26,14 @@ import org.springframework.http.ResponseEntity;
  * End-to-end tests for the manual ("Process IDPC") ingestion endpoint:
  * POST /ingestions/start-by-case
  *
- * <p>Covers all three response phases:
+ * <p>Covers all response phases:
  * <ul>
  *   <li>STARTED — a newer IDPC exists, so the remaining workflow is dispatched;</li>
- *   <li>NOT_REQUIRED — the IDPC has already been ingested (seeded), so nothing is dispatched;</li>
+ *   <li>STARTED (no newer IDPC, answer still pending) — the IDPC has already been ingested but no
+ *       answer has been generated yet for the case, so nothing new is dispatched but the phase is
+ *       still STARTED, not NOT_REQUIRED;</li>
+ *   <li>NOT_REQUIRED — the IDPC has already been ingested <b>and</b> an answer already exists
+ *       (seeded), so nothing is dispatched;</li>
  *   <li>FAILED — the downstream court-document-search call errors (case-specific 500 stub).</li>
  * </ul>
  */
@@ -83,10 +87,25 @@ class IngestionProcessByCaseHttpLiveTest extends AbstractHttpLiveTest {
     }
 
     @Test
-    @DisplayName("Returns NOT_REQUIRED when the IDPC has already been ingested")
+    @DisplayName("Returns STARTED (not NOT_REQUIRED) when the IDPC has already been ingested "
+            + "but no answer has been generated yet")
+    void startByCase_returnsStarted_whenIngestedButAnswerNotYetAvailable() throws Exception {
+        final UUID caseId = UUID.randomUUID();
+        seedExistingCaseDocument(caseId);
+
+        final ResponseEntity<String> response = postByCase(caseId);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).contains("\"phase\":\"STARTED\"");
+        assertThat(response.getBody()).contains("previous answers are still in the process of generating");
+    }
+
+    @Test
+    @DisplayName("Returns NOT_REQUIRED when the IDPC has already been ingested and an answer already exists")
     void startByCase_returnsNotRequired() throws Exception {
         final UUID caseId = UUID.randomUUID();
         seedExistingCaseDocument(caseId);
+        seedAnswerAvailable(caseId);
 
         final ResponseEntity<String> response = postByCase(caseId);
 
@@ -131,6 +150,30 @@ class IngestionProcessByCaseHttpLiveTest extends AbstractHttpLiveTest {
             ps.setObject(11, STUB_COURTDOC_ID);
             ps.setObject(12, now);
             ps.executeUpdate();
+        }
+    }
+
+    /**
+     * Seeds a canonical query plus a {@code case_query_status} row with status
+     * {@code ANSWER_AVAILABLE} for the given case, so the IDPC-availability check finds an answer
+     * already exists.
+     */
+    private void seedAnswerAvailable(final UUID caseId) throws Exception {
+        final UUID queryId = UUID.randomUUID();
+        try (Connection connection = openConnection()) {
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO queries (query_id, label) VALUES (?, ?)")) {
+                ps.setObject(1, queryId);
+                ps.setString(2, "Test query " + queryId);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = connection.prepareStatement(
+                    "INSERT INTO case_query_status (case_id, query_id, status) "
+                            + "VALUES (?, ?, 'ANSWER_AVAILABLE'::query_lifecycle_status_enum)")) {
+                ps.setObject(1, caseId);
+                ps.setObject(2, queryId);
+                ps.executeUpdate();
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/repo/CaseQueryStatusRepository.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/repo/CaseQueryStatusRepository.java
@@ -8,9 +8,21 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CaseQueryStatusRepository extends JpaRepository<CaseQueryStatus, CaseQueryStatusId> {
-    List<CaseQueryStatus> findByCaseId(UUID caseId);
 
-    Optional<CaseQueryStatus> findByCaseIdAndQueryId(UUID caseId, UUID queryId);
+    /**
+     * {@code caseId} lives on the {@link CaseQueryStatusId} embedded id, not directly on
+     * {@link CaseQueryStatus} — a derived {@code findByCaseId} would resolve against the entity's
+     * plain {@code getCaseId()} convenience getter instead, which isn't a mapped JPA attribute, so
+     * the path is spelled out explicitly here.
+     */
+    @Query("SELECT c FROM CaseQueryStatus c WHERE c.caseQueryStatusId.caseId = :caseId")
+    List<CaseQueryStatus> findByCaseId(@Param("caseId") UUID caseId);
+
+    @Query("SELECT c FROM CaseQueryStatus c "
+            + "WHERE c.caseQueryStatusId.caseId = :caseId AND c.caseQueryStatusId.queryId = :queryId")
+    Optional<CaseQueryStatus> findByCaseIdAndQueryId(@Param("caseId") UUID caseId, @Param("queryId") UUID queryId);
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/IngestionProcessorByCaseService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/IngestionProcessorByCaseService.java
@@ -5,7 +5,9 @@ import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.RETRIEVE_MATERIAL_AND_UPL
 import static uk.gov.hmcts.cp.cdk.util.TimeUtils.utcNow;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 
+import uk.gov.hmcts.cp.cdk.domain.QueryLifecycleStatus;
 import uk.gov.hmcts.cp.cdk.jobmanager.support.JobPriority;
+import uk.gov.hmcts.cp.cdk.repo.CaseQueryStatusRepository;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessByCaseRequest;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessPhase;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessResponse;
@@ -30,10 +32,17 @@ import org.springframework.stereotype.Service;
  * HTTP response depends on its outcome:
  * <ul>
  *   <li>no newer IDPC available (this also covers a case that doesn't exist or has no defendants —
- *       {@link IdpcAvailabilityService} simply finds nothing to ingest either way) →
+ *       {@link IdpcAvailabilityService} simply finds nothing to ingest either way) <b>and</b> an
+ *       answer already exists for the case ({@link CaseQueryStatusRepository#findByCaseId} has an
+ *       entry with {@link QueryLifecycleStatus#ANSWER_AVAILABLE}) →
  *       {@link IngestionProcessPhase#NOT_REQUIRED}, nothing dispatched;</li>
- *   <li>newer IDPC available → {@code RETRIEVE_MATERIAL_AND_UPLOAD} is dispatched via the JobManager
- *       at {@link JobPriority#HIGH} priority and {@link IngestionProcessPhase#STARTED} is returned;</li>
+ *   <li>no newer IDPC available and no answer exists yet for the case → nothing new to dispatch
+ *       (the existing documents were already sent for ingestion previously), but
+ *       {@link IngestionProcessPhase#STARTED} is still returned since the answer generation is
+ *       presumed to be in progress;</li>
+ *   <li>newer IDPC available → {@code RETRIEVE_MATERIAL_AND_UPLOAD} is dispatched via the
+ *       JobManager at {@link JobPriority#HIGH} priority for the newer documents found and
+ *       {@link IngestionProcessPhase#STARTED} is returned;</li>
  *   <li>any unexpected error → {@link IngestionProcessPhase#FAILED}.</li>
  * </ul>
  *
@@ -59,12 +68,15 @@ public class IngestionProcessorByCaseService implements IngestionProcessorByCase
                     + "and an Answers version already exists.";
     /* default */ static final String MSG_STARTED =
             "Ingestion workflow request accepted; task submitted via JobManager (requestId=%s).";
+    /* default */ static final String MSG_STARTED_ANSWERS_IN_PROGRESS =
+            "No newer IDPC version is available; previous answers are still in the process of generating.";
     /* default */ static final String MSG_FAILED =
             "Ingestion process could not be started due to an internal error.";
 
     private final IdpcAvailabilityService idpcAvailabilityService;
     private final RetrieveMaterialAndUploadJobDataService retrievalJobDataService;
     private final ExecutionService executionService;
+    private final CaseQueryStatusRepository caseQueryStatusRepository;
 
     @Override
     public IngestionProcessResponse startIngestionProcess(final String cppuid,
@@ -80,22 +92,33 @@ public class IngestionProcessorByCaseService implements IngestionProcessorByCase
                     idpcAvailabilityService.retrieveDocuments(caseId, cppuid);
 
             if (newDocuments.isEmpty()) {
-                log.info("Manual ingestion not required (no newer IDPC version). caseId={}, requestId={}",
-                        caseId, requestId);
-                return notRequired(response, MSG_NOT_REQUIRED_NO_NEWER_IDPC);
+                if (hasAnswerAvailable(caseId)) {
+                    log.info("Manual ingestion not required (no newer IDPC version and an answer already exists). "
+                            + "caseId={}, requestId={}", caseId, requestId);
+                    return notRequired(response, MSG_NOT_REQUIRED_NO_NEWER_IDPC);
+                }
+
+                log.info("No newer IDPC version but no answer exists yet; previous ingestion still in progress, "
+                        + "nothing new to dispatch. caseId={}, requestId={}", caseId, requestId);
+                return started(response, MSG_STARTED_ANSWERS_IN_PROGRESS);
             }
 
             dispatchRetrievalTasks(cppuid, requestId, caseId, newDocuments);
 
             log.info("Manual ingestion started. caseId={}, newIdpcDocuments={}, requestId={}",
                     caseId, newDocuments.size(), requestId);
-            return started(response, requestId);
+            return started(response, MSG_STARTED.formatted(requestId));
 
         } catch (final Exception exception) {
             log.error("Manual ingestion could not be started due to an internal error. "
                     + "caseId={}, requestId={}", caseId, requestId, exception);
             return failed(response);
         }
+    }
+
+    private boolean hasAnswerAvailable(final UUID caseId) {
+        return caseQueryStatusRepository.findByCaseId(caseId).stream()
+                .anyMatch(status -> status.getStatus() == QueryLifecycleStatus.ANSWER_AVAILABLE);
     }
 
     private void dispatchRetrievalTasks(final String cppuid,
@@ -115,9 +138,9 @@ public class IngestionProcessorByCaseService implements IngestionProcessorByCase
         }
     }
 
-    private IngestionProcessResponse started(final IngestionProcessResponse response, final String requestId) {
+    private IngestionProcessResponse started(final IngestionProcessResponse response, final String message) {
         response.setPhase(IngestionProcessPhase.STARTED);
-        response.setMessage(MSG_STARTED.formatted(requestId));
+        response.setMessage(message);
         return response;
     }
 

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/IngestionProcessorByCaseServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/IngestionProcessorByCaseServiceTest.java
@@ -12,7 +12,10 @@ import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_DEFENDANT_ID_KEY;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_DOC_ID_KEY;
 
+import uk.gov.hmcts.cp.cdk.domain.CaseQueryStatus;
+import uk.gov.hmcts.cp.cdk.domain.QueryLifecycleStatus;
 import uk.gov.hmcts.cp.cdk.jobmanager.support.JobPriority;
+import uk.gov.hmcts.cp.cdk.repo.CaseQueryStatusRepository;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessByCaseRequest;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessPhase;
 import uk.gov.hmcts.cp.openapi.model.cdk.IngestionProcessResponse;
@@ -42,6 +45,8 @@ class IngestionProcessorByCaseServiceTest {
     private IdpcAvailabilityService idpcAvailabilityService;
     @Mock
     private ExecutionService executionService;
+    @Mock
+    private CaseQueryStatusRepository caseQueryStatusRepository;
     @Captor
     private ArgumentCaptor<ExecutionInfo> executionInfoCaptor;
 
@@ -52,8 +57,25 @@ class IngestionProcessorByCaseServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new IngestionProcessorByCaseService(idpcAvailabilityService, retrievalJobDataService, executionService);
+        service = new IngestionProcessorByCaseService(
+                idpcAvailabilityService, retrievalJobDataService, executionService, caseQueryStatusRepository);
         caseId = UUID.randomUUID();
+    }
+
+    private CaseQueryStatus answerAvailable() {
+        final CaseQueryStatus status = new CaseQueryStatus();
+        status.setCaseId(caseId);
+        status.setQueryId(UUID.randomUUID());
+        status.setStatus(QueryLifecycleStatus.ANSWER_AVAILABLE);
+        return status;
+    }
+
+    private CaseQueryStatus answerNotAvailable() {
+        final CaseQueryStatus status = new CaseQueryStatus();
+        status.setCaseId(caseId);
+        status.setQueryId(UUID.randomUUID());
+        status.setStatus(QueryLifecycleStatus.ANSWER_NOT_AVAILABLE);
+        return status;
     }
 
     private IngestionProcessByCaseRequest request() {
@@ -88,15 +110,47 @@ class IngestionProcessorByCaseServiceTest {
     }
 
     @Test
-    @DisplayName("Returns NOT_REQUIRED when no newer IDPC version exists")
-    void returnsNotRequired_whenNoNewerIdpc() {
+    @DisplayName("Returns NOT_REQUIRED when no newer IDPC version exists and an answer already exists")
+    void returnsNotRequired_whenNoNewerIdpcAndAnswerExists() {
         when(idpcAvailabilityService.retrieveDocuments(caseId, CPPUID_VALUE))
                 .thenReturn(List.of());
+        when(caseQueryStatusRepository.findByCaseId(caseId))
+                .thenReturn(List.of(answerAvailable()));
 
         final IngestionProcessResponse response = service.startIngestionProcess(CPPUID_VALUE, request());
 
         assertThat(response.getPhase()).isEqualTo(IngestionProcessPhase.NOT_REQUIRED);
         assertThat(response.getMessage()).contains("no newer IDPC version is available");
+        verifyNoInteractions(executionService);
+    }
+
+    @Test
+    @DisplayName("Returns STARTED when no newer IDPC version exists but no answer exists yet")
+    void returnsStarted_whenNoNewerIdpcAndNoAnswerExists() {
+        when(idpcAvailabilityService.retrieveDocuments(caseId, CPPUID_VALUE))
+                .thenReturn(List.of());
+        when(caseQueryStatusRepository.findByCaseId(caseId))
+                .thenReturn(List.of(answerNotAvailable()));
+
+        final IngestionProcessResponse response = service.startIngestionProcess(CPPUID_VALUE, request());
+
+        assertThat(response.getPhase()).isEqualTo(IngestionProcessPhase.STARTED);
+        assertThat(response.getMessage()).contains("previous answers are still in the process of generating");
+        verifyNoInteractions(executionService);
+    }
+
+    @Test
+    @DisplayName("Returns STARTED when no newer IDPC version exists and no case query status is recorded")
+    void returnsStarted_whenNoNewerIdpcAndNoCaseQueryStatus() {
+        when(idpcAvailabilityService.retrieveDocuments(caseId, CPPUID_VALUE))
+                .thenReturn(List.of());
+        when(caseQueryStatusRepository.findByCaseId(caseId))
+                .thenReturn(List.of());
+
+        final IngestionProcessResponse response = service.startIngestionProcess(CPPUID_VALUE, request());
+
+        assertThat(response.getPhase()).isEqualTo(IngestionProcessPhase.STARTED);
+        assertThat(response.getMessage()).contains("previous answers are still in the process of generating");
         verifyNoInteractions(executionService);
     }
 


### PR DESCRIPTION
## Summary
- `IngestionProcessorByCaseService.startIngestionProcess` (`POST /ingestions/start-by-case`) reported `IngestionProcessPhase.NOT_REQUIRED` whenever no newer IDPC document existed, even if no answer had ever been generated for the case (e.g. answer generation failed after a previous ingestion). It now also checks `CaseQueryStatusRepository` for an `ANSWER_AVAILABLE` entry: `NOT_REQUIRED` is only returned when an answer already exists; otherwise it returns `STARTED` with a distinct message ("No newer IDPC version is available; previous answers are still in the process of generating.") and dispatches nothing new.
- Fixed a latent bug this change surfaced: `CaseQueryStatusRepository.findByCaseId`/`findByCaseIdAndQueryId` were broken derived Spring Data queries — they resolved against the entity's plain `caseId` getter instead of the `@EmbeddedId`, throwing `UnknownPathException` the first time they were actually invoked at runtime. Both now use explicit JPQL through `caseQueryStatusId.caseId`/`.queryId`.

## Test plan
- [x] `IngestionProcessorByCaseServiceTest` — added/updated unit tests covering: answer exists → `NOT_REQUIRED`; no answer yet → `STARTED`; no `CaseQueryStatus` row at all → `STARTED`.
- [x] `IngestionProcessByCaseHttpLiveTest` — split the old `NOT_REQUIRED` scenario into two: ingested-but-no-answer-yet (`STARTED`) and ingested-with-answer (`NOT_REQUIRED`, now seeding a `case_query_status(ANSWER_AVAILABLE)` row).
- [x] `gradle test pmdMain pmdTest` — green.
- [x] `gradle integration --tests IngestionProcessByCaseHttpLiveTest` — all 4 scenarios pass against the real docker-compose stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)