### PR TITLE
Bump api-cp-ai-rag contract dependency to 0.0.15

### DIFF
--- a/.claude/context/tech-stack.md
+++ b/.claude/context/tech-stack.md
@@ -98,7 +98,7 @@ All APIM calls carry a subscription key or AAD token injected by `ApimAuthHeader
 | Dependency | Version | Purpose |
 |-----------|---------|---------|
 | `api-cp-crime-caseadmin-case-document-knowledge` | 0.0.11 | OpenAPI models for CSDK own API |
-| `api-cp-ai-rag` | 0.0.12 | RAG service API models |
+| `api-cp-ai-rag` | 0.0.15 | RAG service API models |
 | `cp-auth-rules-filter` | 1.0.7 | Drools-based HTTP authorization |
 | `cp-audit-filter-springboot` | 1.0.5 | Audit event filter (publishes to Artemis) |
 | `task-manager-service` | 1.0.10 | Job/task orchestration client |

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 JAVA_VERSION=25
 version.cdk=0.0.11
-version.aiRag=0.0.12
+version.aiRag=0.0.15
 version.apiSpec=0.4.2
 version.lombok=1.18.42
 version.mapstruct=1.5.5.Final


### PR DESCRIPTION
## Summary
- Bump `version.aiRag` from `0.0.12` to `0.0.15` in `gradle.properties`
- Update `.claude/context/tech-stack.md` to reflect the new `api-cp-ai-rag` version

## Contract impact
Compared the `api-cp-ai-rag` jar between 0.0.12 and 0.0.15 (class list + `javap` signatures):
- Only change: the unused `DocumentStatusNotAvailable` model class was removed from the contract. It is not referenced anywhere in this repo.
- All API interfaces (`DocumentIngestionInitiationApi`, `DocumentIngestionStatusApi`, `DocumentInformationSummarisedAsynchronouslyApi`/`SynchronouslyApi`) and all model classes actually used in `src/main` (`AnswerUserQueryRequest`, `DocumentChunk`, `DocumentIngestionStatus`, `UserQueryAnswerRequestAccepted`, `UserQueryAnswerReturnedSuccessfullySynchronously`/`Asynchronously`, etc.) have identical signatures — no breaking change to the RAG response contract.
- Only transitive POM dependency versions bumped (jakarta annotations, swagger-annotations, spring-web, jackson-databind-nullable); no new/removed dependencies.

## Test plan
- [x] `gradle compileJava` — succeeds against 0.0.15
- [x] `gradle test` — all unit tests pass
- [x] `gradle integration` — full suite passes (`BUILD SUCCESSFUL`); an initial run had 2 flaky `Awaitility` timeouts in `IngestionProcessHttpLiveTest`, reproduced as non-reproducible on isolated re-run and on a full clean re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)