### PR TITLE
Default scheduler and hearing-lookup flags to disabled

### DIFF
--- a/src/main/resources/application-cdk.yml
+++ b/src/main/resources/application-cdk.yml
@@ -59,11 +59,11 @@ scheduler:
     cron: "0 0/10 7-19 * * MON-FRI"  # every 10 min, Mon–Fri, 07:00–19:50
     lock-at-least-for: "PT8M"
     lock-at-most-for: "PT9M"
-    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:false}
   nightly-discovery:
     name: "nightlyDiscoveryScheduler"
     cron: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_CRON:0 0 2 * * *}"  # daily at 02:00
     lock-at-least-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_LEAST_FOR:PT1H}"
     lock-at-most-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_MOST_FOR:PT2H}"
-    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:false}
     days-ahead: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_DAYS_AHEAD:3}

--- a/src/main/resources/application-clients.yml
+++ b/src/main/resources/application-clients.yml
@@ -25,7 +25,7 @@ cqrs:
       get-hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
       get-hearing-cases-for-day-accept-header: "application/vnd.hearing.get.hearing-cases-for-day+json"
       get-hearing-cases-for-day-path: "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day"
-      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:true}
+      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:false}
     progression:
       accept-header: "application/vnd.progression.query.courtdocuments+json"
       doc-type-id: "41be14e8-9df5-4b08-80b0-1e670bc80a5b"


### PR DESCRIPTION
## Summary
- Default `CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED`, `CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED`, and `CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED` to `false` in `application-cdk.yml` / `application-clients.yml`, so schedulers and the hearing-for-cases lookup ship switched off and must be explicitly enabled per environment.
- `CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED` had regressed to `true` on this branch (it was `false` on `main`); the other two are new flags introduced on this branch that defaulted to `true`.

## Test plan
- [ ] `gradle test`
- [ ] `gradle integration` (compose stack still sets these to `true` explicitly for integration tests, which is unaffected by this change)
- [ ] Confirm no scheduler runs / hearing-for-cases lookup fires on a fresh boot with no env vars set

🤖 Generated with [Claude Code](https://claude.com/claude-code)