### PR TITLE
Default scheduler and hearing-lookup flags to disabled

### DIFF
--- a/src/integrationTest/resources/wiremock/__files/hearing_cases_for_day_api_response.json
+++ b/src/integrationTest/resources/wiremock/__files/hearing_cases_for_day_api_response.json
@@ -1,0 +1,3 @@
+{
+  "hearingCases": []
+}

--- a/src/integrationTest/resources/wiremock/mappings/hearing_cases_for_day_api.json
+++ b/src/integrationTest/resources/wiremock/mappings/hearing_cases_for_day_api.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day",
+    "queryParameters": {
+      "date": { "matches": ".*" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "hearing_cases_for_day_api_response.json"
+  }
+}

--- a/src/main/resources/application-cdk.yml
+++ b/src/main/resources/application-cdk.yml
@@ -59,11 +59,11 @@ scheduler:
     cron: "0 0/10 7-19 * * MON-FRI"  # every 10 min, Mon–Fri, 07:00–19:50
     lock-at-least-for: "PT8M"
     lock-at-most-for: "PT9M"
-    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:false}
   nightly-discovery:
     name: "nightlyDiscoveryScheduler"
     cron: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_CRON:0 0 2 * * *}"  # daily at 02:00
     lock-at-least-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_LEAST_FOR:PT1H}"
     lock-at-most-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_MOST_FOR:PT2H}"
-    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:false}
     days-ahead: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_DAYS_AHEAD:3}

--- a/src/main/resources/application-clients.yml
+++ b/src/main/resources/application-clients.yml
@@ -25,7 +25,7 @@ cqrs:
       get-hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
       get-hearing-cases-for-day-accept-header: "application/vnd.hearing.get.hearing-cases-for-day+json"
       get-hearing-cases-for-day-path: "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day"
-      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:true}
+      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:false}
     progression:
       accept-header: "application/vnd.progression.query.courtdocuments+json"
       doc-type-id: "41be14e8-9df5-4b08-80b0-1e670bc80a5b"


### PR DESCRIPTION
## Summary
- Restores `false` defaults for `CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED`, `CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED`, and `CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED`, which had reverted to `true` on `main`.
- Root cause: the disable-by-default fix (#208) was merged only into `release_2623`. `develop` was merged into `main` separately (#209) without ever incorporating `release_2623`'s fix, so `main` (and `develop`) kept shipping with these flags on by default.
- Adds a permanent low-priority WireMock stub for `/hearing-cases-for-day` (empty `hearingCases` response), matching the existing pattern used for `/hearings`. Fixes an intermittent 404 ("closest stub not matching") in CI integration tests: background scheduler cron ticks in the docker-compose stack were hitting this endpoint before `NightlyDiscoverySchedulerLiveTest` registered its own dynamic stub.

## Test plan
- [x] `gradle integration --tests "*NightlyDiscoverySchedulerLiveTest*" --tests "*IntradayDiscoverySchedulerLiveTest*"` — all 6 tests pass (3 per class, 0 failures/errors) against the docker-compose stack.
- [ ] Full `gradle clean build` / CI pipeline run.
- [ ] Separately port this same flag-default fix into `develop` so it doesn't regress on the next release merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)