### PR TITLE
[DD-43036] User stories generated using Claude

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,16 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+
 # HMCTS SDLC Pipeline — case-document-knowledge-service (CSDK)
 
-> Tailored from `hmcts-sdlc-orchestrator` for this repo. The 8-stage pipeline, gates, agents,
-> skills and `context/*` docs come from the installed plugin — install it first
+> Tailored from `hmcts-sdlc-orchestrator` for this repo — install the plugin first
 > (`/plugin install hmcts-sdlc-orchestrator@agentic-plugins-marketplace`) or the references below
-> will not resolve.
+> will not resolve. Only `csdk-context.md` and `tech-stack.md` are CSDK-specific and stored locally
+> under `.claude/context/`; every other context doc, pipeline agent, and auxiliary agent/skill
+> below lives in the plugin itself (`$PLUGIN` = `~/.claude/plugins/marketplaces/agentic-plugins-marketplace/plugins/agents/hmcts-sdlc-orchestrator`)
+> — don't copy plugin content into this repo, it will just drift out of sync.
 
 ## Project context
 
@@ -18,15 +25,16 @@ This is an HMCTS engineering project. All work must comply with HMCTS engineerin
 Service Manual, and MOJ security and accessibility requirements.
 
 Always load before any pipeline stage:
-- `.claude/context/csdk-context.md` — **single source of truth**: stack, packages, integrations, API surface, hard rules. Load this first.
-- `.claude/context/tech-stack.md`
-- `.claude/context/hmcts-standards.md`
-- `.claude/context/azure-cloud-native.md` — Cloud-Native posture and Shared Responsibility Model on Azure.
-- `.claude/context/logging-standards.md` — mandatory JSON logging for Spring Boot services.
+- `.claude/context/csdk-context.md` — **single source of truth**: stack, packages, integrations, API surface, hard rules. Load this first. **CSDK-specific, stored locally.**
+- `.claude/context/tech-stack.md` — CSDK's actual versions, packages, and layout. **CSDK-specific, stored locally.**
+- `$PLUGIN/context/hmcts-standards.md`
+- `$PLUGIN/context/azure-cloud-native.md` — Cloud-Native posture and Shared Responsibility Model on Azure.
+- `$PLUGIN/context/logging-standards.md` — mandatory JSON logging for Spring Boot services.
 
 Load on demand:
-- `.claude/context/azure-sdk-guide.md` — when touching any Azure integration (this service uses Managed Identity; see `clients/common/Azure*`).
-- `.claude/context/cloud-adoption-rationale.md` — only when lock-in / cloud-cost trade-offs or an ADR require it. Do not auto-load.
+- `$PLUGIN/context/azure-sdk-guide.md` — when touching any Azure integration (this service uses Managed Identity; see `clients/common/Azure*`).
+- `$PLUGIN/context/cloud-adoption-rationale.md` — only when lock-in / cloud-cost trade-offs or an ADR require it. Do not auto-load.
+- `$PLUGIN/context/coding-standards.md` — Java/Spring Boot naming, structure, method-size, and error-handling conventions. Load during the Code and Code Review stages.
 
 ## Tech stack & layout
 
@@ -57,16 +65,29 @@ Source sets:
 
 Run in order. Do not skip or reorder. Halt at every human gate before proceeding.
 
-| # | Stage                 | Agent file                          | Gate  |
-|---|-----------------------|-------------------------------------|-------|
-| 1 | Requirements          | agents/requirements-analyst.md      | Human |
-| 2 | Architecture & Design | agents/architecture-designer.md     | Human |
-| 3 | User Story            | agents/story-writer.md              | Human |
-| 4 | Test Specs            | agents/test-engineer.md             | Human |
-| 5 | Code                  | agents/implementation.md            | Auto  |
-| 6 | Code Review           | agents/code-reviewer.md             | Human |
-| 7 | Build & Test          | agents/ci-orchestrator.md           | Auto  |
-| 8 | Deploy Sandbox        | agents/deployer.md                  | Human |
+| # | Stage                 | Agent                                                    | Gate  |
+|---|-----------------------|-----------------------------------------------------------|-------|
+| 1 | Requirements          | `hmcts-sdlc-orchestrator:requirements-analyst` (plugin)    | Human |
+| 2 | Architecture & Design | `hmcts-sdlc-orchestrator:architecture-designer` (plugin)†  | Human |
+| 3 | User Story            | `hmcts-sdlc-orchestrator:story-writer` (plugin)            | Human |
+| 4 | Test Specs            | `hmcts-sdlc-orchestrator:test-engineer` (plugin)           | Human |
+| 5 | Code                  | `.claude/agents/implementation.md` (**local override**)    | Auto  |
+| 6 | Code Review           | `hmcts-sdlc-orchestrator:code-reviewer` (plugin)           | Human |
+| 7 | Build & Test          | `.claude/agents/ci-orchestrator.md` (**local override**)   | Auto  |
+| 8 | Deploy Sandbox        | `hmcts-sdlc-orchestrator:deployer` (plugin)                | Human |
+
+> **Local overrides:** `implementation` and `ci-orchestrator` are project-local rewrites of the
+> plugin's generic agents, not copies — they encode CSDK-specific facts the plugin template can't
+> know (actual GitHub Actions workflow names, the ADO trigger pipeline ID, JDK/Temurin version,
+> Docker images, Flyway/Artemis/Azurite failure-triage tables, and CSDK's
+> `@Slf4j @RestController implements FooApi` controller pattern). The plugin has no changelog —
+> if it's upgraded, diff these two files by hand against the plugin's versions to catch drift.
+>
+> † `architecture-designer` is the only "Human" gate stage whose own agent file has no
+> self-declared halt instruction (unlike `requirements-analyst`, `story-writer`, and
+> `test-engineer`, which each explicitly say to halt and wait for confirmation). It's still
+> covered by the "never proceed past a human gate" hard rule below, but don't assume the agent
+> will stop itself — the orchestrating session must enforce the pause.
 
 ---
 
@@ -81,24 +102,66 @@ Run in order. Do not skip or reorder. Halt at every human gate before proceeding
 | `migration-reviewer` (agent) | **Any change under `db/migration`** — Flyway migrations are append-only and versioned |
 | `rbac-auditor` (agent) | Changes to `controllers/accesscontrol/`, `PermissionConstants`, or `resources/acl/` |
 | `doc-generator` / `adr-template` | API docs (OpenAPI) and recording architecture decisions |
+| `research` (agent) | Tracing CSDK's integration with the upstream RAG service or the companion OpenAPI spec repo — broader than `event-flow-mapper`'s Artemis-only scope |
+| `test-analyzer` (agent) | Coverage-gap / flaky-test analysis across `test`, `integrationTest`, `pactVerificationTest` |
+| `api-contract-check` (skill) | Verify controllers/DTOs stay consistent with the consumed `api-cp-crime-caseadmin-case-document-knowledge` OpenAPI artefact (`build.gradle`) |
+| `review-checklist` (skill) | Code Review stage, alongside `review-pr` — Spring Boot/Azure/logging checklist items map directly onto CSDK's hard rules |
+| `write-acceptance-criteria` (skill) | Requirements stage — deriving ACs from FRs |
+| `springboot-service-from-template` (skill) | Template-alignment check — ties to the hard rule against hand-scaffolding build files/Dockerfile/logback |
 
-> Not applicable in this repo: `helm-config-validator` / `terraform-validate` — there are **no Helm charts
-> or Terraform** here (deployment infra lives elsewhere). Skip them unless infra is added to this repo.
+> Not applicable in this repo:
+> - `helm-config-validator` / `terraform-validate` — there are **no Helm charts or Terraform**
+>   here (deployment infra lives elsewhere). Skip unless infra is added to this repo.
+> - `context-scaffold` / `context-service-guide` — legacy WildFly `cpp-context-*` only; CSDK is
+>   Spring Boot (Modern by Default).
+> - `pipeline-debug` — needs an in-repo `azure-pipelines.yml` to trace; CSDK's CI is 100% GitHub
+>   Actions. The `hmcts/trigger-ado-pipeline` step only fires an external pipeline by ID — there's
+>   no template in this repo for the skill to debug.
+> - `springboot-api-from-template` — for bootstrapping a brand-new API-spec repo; CSDK already
+>   consumes an established one.
+> - `accessibility-check` — CSDK is backend-only with no UI to scan. Hard rule below on WCAG 2.1 AA
+>   is inherited from the HMCTS template and applies to downstream consumers of CSDK's API, not to
+>   CSDK itself.
 
 ---
 
 ## Artefact output convention
 
-All pipeline artefacts go to `docs/pipeline/`:
+Every requirement gets its own folder under `docs/pipeline/`, scoped by Jira ticket, so
+successive requirements never overwrite each other's artefacts and each stage's output stays
+traceable back to its ticket:
 
 ```
 docs/pipeline/
-├── requirements.md
-├── user-stories/<story-id>.md
-├── test-specs/<story-id>.feature
-├── adrs/<NNN>-<title>.md
-└── deploy-notes.md
+├── adrs/
+│   └── <JIRA-TICKET>-<slug>.md
+└── <JIRA-TICKET>-<slug>/
+    ├── 00-input-brief.md
+    ├── 01-requirements.md
+    ├── 02-design.md
+    ├── 03-stories.md
+    ├── 04-test-specs.md
+    └── deploy-notes.md
 ```
+
+- `00-input-brief.md` — the raw, unstructured input as given (brief, Confluence page, Jira epic).
+- `01-requirements.md` — Requirements stage output.
+- `02-design.md` — Architecture & Design stage output (low-level design).
+- `03-stories.md` — User Story stage output; all stories split out of the requirement in one file.
+- `04-test-specs.md` — Test Specs stage output: test scenarios (Given/When/Then or equivalent, in
+  prose) for the integration tests to be written in `src/integrationTest/`, grouped by story — a
+  story can have more than one integration test scenario.
+- `deploy-notes.md` — Deploy Sandbox stage output.
+
+`docs/pipeline/adrs/<JIRA-TICKET>-<slug>.md` — one ADR file per requirement, under a shared `adrs/`
+folder, named with the **same `<JIRA-TICKET>-<slug>` convention** as the requirement's own folder
+so the two stay trivially traceable to each other. All architecturally-significant decisions raised
+while working that requirement go in this one file, as numbered sections (`## ADR-001: <title>`,
+`## ADR-002: <title>`, ... — numbering is local to the file, one sequence per requirement).
+
+Create the requirement folder on first use (Requirements stage) — no pre-scaffolding required.
+Create its matching `adrs/<JIRA-TICKET>-<slug>.md` the first time a decision needs recording; not
+every requirement will need one.
 
 ---
 
@@ -108,11 +171,12 @@ docs/pipeline/
 - **Never invent requirements, ACs, or test data** — flag unknowns as open questions. Every story needs a linked Jira ticket before the test stage.
 - **Preserve RAG response data** — any change to the ingestion or answer-serving flow must not drop or transform source fields returned by the RAG service (e.g. `doc_id`, `llm_input`). Citation production is the RAG service's responsibility; CSDK's responsibility is not to lose that data.
 - **No PII / case data / court reference numbers** in artefacts, prompts, logs, or test fixtures. Use synthetic data; WireMock stubs and Azurite seed data must be non-real.
-- **JSON logging to stdout is mandatory** (`logback-spring.xml`). No `System.out`; no logging of case content or document bodies. See `context/logging-standards.md`.
-- **Azure via Managed Identity only.** Connection strings, SAS tokens, and account keys are not permitted in code, config, env vars, or compose files. Use the existing `Azure*`/APIM client pattern. See `context/azure-sdk-guide.md`.
+- **Security hooks are enforced automatically by the plugin** — `block-pii` and `block-secrets` run on every prompt and on every `Write`/`Edit`, `guard-bash` runs on every `Bash` call, and `guard-paths` runs on every `Read`/`Write`/`Edit` (`$PLUGIN/hooks/hooks.json`). These back the PII and Managed-Identity rules above; don't bypass or work around a hook block — treat it as a signal to fix the underlying content, not the gate.
+- **JSON logging to stdout is mandatory** (`logback-spring.xml`). No `System.out`; no logging of case content or document bodies. See `$PLUGIN/context/logging-standards.md`.
+- **Azure via Managed Identity only.** Connection strings, SAS tokens, and account keys are not permitted in code, config, env vars, or compose files. Use the existing `Azure*`/APIM client pattern. See `$PLUGIN/context/azure-sdk-guide.md`.
 - **Flyway migrations are append-only** — never edit a shipped `V*.sql`; add the next version. Route migration changes through `migration-reviewer`.
 - **Integration tests are part of `build`/`check`** — code is not "done" until `gradle integration` passes against the compose stack.
 - **Quality gates** — PMD and JaCoCo must pass; do not lower thresholds to go green. CodeQL and the secrets scanner must be clean.
 - **Use the HMCTS Spring Boot templates** as the master source for build files, Dockerfile, and logback config — do not hand-scaffold. Deviations require an ADR.
 - **Accessibility (WCAG 2.1 AA)** is non-negotiable for any user-facing output.
-- If confidence in a decision is low, write an ADR (`docs/pipeline/adrs/`) and surface it for review.
+- If confidence in a decision is low, write an ADR (`docs/pipeline/adrs/<JIRA-TICKET>-<slug>.md`) and surface it for review.

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/00-input-brief.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/00-input-brief.md
@@ -1,0 +1,19 @@
+# 00 — Input Brief
+
+> Raw, unstructured input as given by the requester. Jira ticket: **DD-43036**.
+
+## Brief (verbatim)
+
+Add a new endpoint to trigger scheduled jobs intraday / nightly.
+
+The endpoint should be accessible only for the System Users (same as
+`casedocumentknowledge-service.discovery-scheduler-configuration` endpoint).
+
+The user input would be the scheduler to kick off i.e. INTRADAY or NIGHTLY.
+
+On receiving the request, based on the input that specific discovery operation should be
+performed.
+
+## Source
+
+Provided directly in conversation by the requester (no Confluence/Jira source document supplied).

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/01-requirements.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/01-requirements.md
@@ -1,0 +1,93 @@
+# Requirements: Manual Discovery Scheduler Trigger Endpoint
+
+> **Stage 1 — Requirements** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Jira: DD-43036**
+> Gate decisions (concurrency, response contract, granularity, path) are folded in below — see `02-design.md` and [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md) (ADR-001/002).
+
+---
+
+## Context
+
+CSDK runs two ShedLock-guarded scheduled discovery jobs — intraday (every 10 min, Mon–Fri 07:00–19:50) and nightly (daily 02:00) — via `DiscoveryService.runIntradayDiscovery()` / `runNightlyDiscovery()`. Today the only way to run either is to wait for its cron. This adds a System-User-only endpoint, `POST /discovery-scheduler/trigger`, to run one named operation (`INTRADAY`/`NIGHTLY`) on demand, reusing both operations unchanged.
+
+Operational driver (missed-run recovery, smoke-testing, support reprocessing) is unstated and should be confirmed before go-live/production rollout.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | `POST /discovery-scheduler/trigger`, alongside `/discovery-scheduler/configurations`. |
+| FR-002 | Body carries one enum discriminator `discoveryOperation`: `INTRADAY` \| `NIGHTLY`, contract-defined. |
+| FR-003 / FR-004 | `INTRADAY` → `runIntradayDiscovery()`; `NIGHTLY` → `runNightlyDiscovery()`. |
+| FR-005 | Reuse existing operations as-is — no duplicated/forked/altered logic; `DiscoveryService` signatures unchanged. |
+| FR-006 / FR-007 | `"System Users"` group only (new Drools rule, no `"AI search"` fallback); anyone else denied, nothing dispatched. |
+| FR-008 | Missing/invalid discriminator → 400 via existing `GlobalExceptionHandler`, nothing dispatched. |
+| FR-009 | Contract-first: operation added & released in `api-cp-crime-caseadmin-case-document-knowledge`, `version.cdk` bumped, before implementation. |
+| FR-010 | Purely additive — cron expressions, lock names/durations, `scheduler.*.enabled` all unchanged. |
+| FR-011 | Structured JSON start/completion log per trigger, correlated, no case data/`CJSCPPUID`. |
+| FR-012 | `202 Accepted`, fire-and-forget — no blocking, no per-item outcome (accept-and-log, like today's schedulers). |
+| FR-013 | No coordination with the `intraday`/`nightlyDiscoveryScheduler` ShedLock — overlap with a live cron run is an accepted risk (ADR-001). |
+
+**Out of scope:** parameterising the run, a third operation, cancel/pause/resume, run-status/history, new persistence, rate limiting, any RAG/ingestion-internals change.
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | AuthZ | `"System Users"` only, no permission fallback. |
+| NFR-002 | Logging | No PII/case content/`CJSCPPUID` in logs, errors, or artefacts. |
+| NFR-003 | Cloud identity | Downstream calls stay on Managed Identity/APIM; no static credentials introduced. |
+| NFR-004 | Concurrency | Accepted limitation (FR-013): possible duplicate dispatch if overlapping a live cron run — stated in contract + runbook, not hidden. |
+| NFR-005 | Performance | Response independent of the (unbounded) run's completion (FR-012). |
+| NFR-006 | Reliability | Per-item dispatch failure doesn't abort the run (existing `DiscoveryService` behaviour). |
+| NFR-007 | Observability | Manual run distinguishable from cron run in logs, correlated by correlation id. |
+| NFR-008 | Auditability | Trigger produces an audit trail via existing `cp-audit-filter-springboot` → Artemis. |
+| NFR-009 | Data protection | No new personal data, no new persistence. |
+| NFR-010 | Testability | Unit + `integrationTest` coverage for authorised/unauthorised/invalid cases; `gradle integration` passes. |
+| NFR-011 | Code quality | PMD/JaCoCo unmodified; CodeQL/secrets-scanner clean. |
+| NFR-012 | Platform | Java 25 / Spring Boot 4.0.5 / Gradle 9; `@Slf4j @RestController implements <Generated>Api` pattern. |
+| NFR-013 | Accessibility | N/A directly (backend-only); applies to any future UI consumer. |
+
+---
+
+## Acceptance Criteria
+
+**Endpoint & discriminator**
+- AC-001: Valid System User request → `202 Accepted`, operation dispatched.
+- AC-002: Wrong HTTP method → `405`, nothing dispatched.
+- AC-003: Request model exposes exactly `INTRADAY`/`NIGHTLY` — no third value, no free text.
+
+**Operation execution**
+- AC-004 / AC-005: `INTRADAY`/`NIGHTLY` runs only its own operation, not the other's.
+- AC-006: `runIntradayDiscovery()`/`runNightlyDiscovery()` stay the single implementation, used by both cron and this endpoint.
+- AC-007: Existing intraday/nightly test suites pass unmodified.
+
+**Access control**
+- AC-008: `"System Users"` member → authorised.
+- AC-009: `"AI search"`-only caller → denied (403), nothing dispatched.
+- AC-010: No `CJSCPPUID` → denied (401), nothing dispatched.
+- AC-011: New Drools rule has exactly one group-membership condition — no `hasPermission`, no `or` — matching `discovery-scheduler-configuration`.
+
+**Invalid input**
+- AC-012–014: Missing field / unrecognised value / malformed JSON → `400` (`ErrorResponse`; malformed JSON message is `"Malformed request body"`), nothing dispatched.
+- AC-015: None of the above error bodies contain a case identifier, court reference, document content, or `CJSCPPUID`.
+
+**Contract-first delivery**
+- AC-016: `version.cdk` references a released contract version with the new operation; controller implements the generated interface, no hand-scaffolded mapping.
+
+**Fire-and-forget & logging**
+- AC-017: `202` returns well before a `NIGHTLY` run could complete.
+- AC-018: Exactly one start + one completion log record per run, both carrying the request's correlation id.
+- AC-019: Manual run distinguishable from a cron run by an explicit field, not timestamp inference.
+- AC-020: No log record from a manual run contains `CJSCPPUID`, case identifier, court reference, document content, or answer text.
+
+**Non-functional**
+- AC-021: Manual trigger overlapping a locked cron run behaves per ADR-001's accepted-risk position (documented, not prevented).
+- AC-022: A per-item dispatch failure doesn't stop remaining dispatches; failure is logged.
+- AC-023: An audit event exists identifying the action and its time.
+- AC-024: `gradle clean build` (incl. `integration`) passes; PMD/JaCoCo green at existing thresholds.
+- AC-025: Diff introduces no connection string, SAS token, account key, or other static credential.

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/01-requirements.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/01-requirements.md
@@ -1,6 +1,6 @@
 # Requirements: Manual Discovery Scheduler Trigger Endpoint
 
-> **Stage 1 — Requirements** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Stage 1 — Requirements** · Service: `cp-case-document-knowledge-service` (CDKS)
 > **Jira: DD-43036**
 > Gate decisions (concurrency, response contract, granularity, path) are folded in below — see `02-design.md` and [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md) (ADR-001/002).
 
@@ -8,7 +8,7 @@
 
 ## Context
 
-CSDK runs two ShedLock-guarded scheduled discovery jobs — intraday (every 10 min, Mon–Fri 07:00–19:50) and nightly (daily 02:00) — via `DiscoveryService.runIntradayDiscovery()` / `runNightlyDiscovery()`. Today the only way to run either is to wait for its cron. This adds a System-User-only endpoint, `POST /discovery-scheduler/trigger`, to run one named operation (`INTRADAY`/`NIGHTLY`) on demand, reusing both operations unchanged.
+CDKS runs two ShedLock-guarded scheduled discovery jobs — intraday (every 10 min, Mon–Fri 07:00–19:50) and nightly (daily 02:00) — via `DiscoveryService.runIntradayDiscovery()` / `runNightlyDiscovery()`. Today the only way to run either is to wait for its cron. This adds a System-User-only endpoint, `POST /discovery-scheduler/trigger`, to run one named operation (`INTRADAY`/`NIGHTLY`) on demand, reusing both operations unchanged.
 
 Operational driver (missed-run recovery, smoke-testing, support reprocessing) is unstated and should be confirmed before go-live/production rollout.
 

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/02-design.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/02-design.md
@@ -1,0 +1,211 @@
+# Design: Manual Discovery Scheduler Trigger Endpoint
+
+> **Stage 2 — Architecture & Design** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Jira: DD-43036** · Requirements: [`01-requirements.md`](./01-requirements.md) · ADRs: [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md)
+> `POST /discovery-scheduler/trigger` — enum discriminator (`INTRADAY`/`NIGHTLY`), returns `202 Accepted` immediately, dispatches the existing `DiscoveryService` operation onto a dedicated bounded executor. `DiscoveryService` itself is not touched.
+
+---
+
+## Detailed Design
+
+### 1. Contract change (external repo — do this first)
+
+**Repo:** `api-cp-crime-caseadmin-case-document-knowledge` · `0.0.11` → new version, then bump `version.cdk` (`gradle.properties:2`). Nothing here compiles until the operation exists in the jar.
+
+Add under the existing `Discovery Scheduler` tag (keeps it on the existing generated `DiscoverySchedulerApi`):
+
+```yaml
+  /discovery-scheduler/trigger:
+    post:
+      tags: [Discovery Scheduler]
+      operationId: triggerDiscovery
+      requestBody:
+        required: true
+        content:
+          application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json:
+            schema: {$ref: '#/components/schemas/DiscoveryTriggerRequest'}
+      responses:
+        '202':
+          content:
+            application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json:
+              schema: {$ref: '#/components/schemas/DiscoveryTriggerResponse'}
+        '400':
+          content:
+            application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json:
+              schema: {$ref: '#/components/schemas/ErrorResponse'}
+```
+
+```yaml
+    DiscoveryOperation:
+      type: string
+      enum: [INTRADAY, NIGHTLY]
+    DiscoveryTriggerRequest:
+      type: object
+      required: [discoveryOperation]
+      properties:
+        discoveryOperation: {$ref: '#/components/schemas/DiscoveryOperation'}
+    DiscoveryTriggerResponse:
+      type: object
+      required: [discoveryOperation, message]
+      properties:
+        discoveryOperation: {$ref: '#/components/schemas/DiscoveryOperation'}
+        message: {type: string, example: "Discovery run dispatched."}
+        correlationId: {type: string, description: "Correlation id the dispatched run logs under."}
+```
+
+- **Vendor media type is load-bearing.** `cp-auth-rules-filter` derives the Drools action name from it: `...discovery-scheduler-trigger+json` → action `casedocumentknowledge-service.discovery-scheduler-trigger`. Change one, change both.
+- `required: [discoveryOperation]` turns a missing field into a clean 400 rather than a 500.
+- One enum, not two paths — one ACL rule; leaves the door open to split `INTRADAY`/`NIGHTLY` permissions later.
+- No `409`/`429` response — not implemented.
+
+### 2. Files touched
+
+| File | Change |
+|---|---|
+| `controllers/DiscoverySchedulerController.java` | Add `@Override triggerDiscovery(...)`. |
+| `services/DiscoveryTriggerService.java` *(new)* | Maps enum → `DiscoveryService` method, submits to executor, owns start/finish/failure logging. |
+| `config/DiscoveryTriggerConfig.java` *(new)* | `discoveryTriggerExecutor` bean; binds properties. |
+| `config/MdcCopyingTaskDecorator.java` *(new)* | Captures submitting thread's MDC onto the worker thread. |
+| `config/DiscoveryTriggerProperties.java` *(new)* | `cp.cdk.discovery-trigger.*` (queue-capacity, await-termination-seconds). |
+| `acl/cdks-rules.drl` | Append one rule. |
+| `gradle.properties` | Bump `version.cdk`. |
+| `application-cdk.yml` | Add `cp.cdk.discovery-trigger.*`. |
+
+**Not changed:** `DiscoveryService.java`, both scheduler classes, `ShedLockConfig.java`, `GlobalExceptionHandler.java`, `db/migration/**`, any existing `.drl` rule or endpoint — verifiable from the diff's file list alone.
+
+### 3. Controller
+
+One method on the existing `DiscoverySchedulerController` (already `implements DiscoverySchedulerApi`) — same resource namespace and actor as the configuration endpoint. No mapping annotation of its own; path comes from the generated interface.
+
+```
+ResponseEntity<DiscoveryTriggerResponse> triggerDiscovery(@RequestBody @Valid DiscoveryTriggerRequest request)
+  -> log.debug(...)
+  -> discoveryTriggerService.trigger(request.getDiscoveryOperation())
+  -> return ResponseEntity.status(ACCEPTED).contentType(VND_DISCOVERY_SCHEDULER_TRIGGER).body(response)
+```
+
+DTOs are contract-generated (`uk.gov.hmcts.cp.openapi.model.cdk`) — no hand-rolled enum, deserialiser, or mapper.
+
+### 4. Access control
+
+```drl
+rule "Allow LA – discovery-scheduler-trigger"
+when
+  $o: Outcome()
+  $a: Action(name == "casedocumentknowledge-service.discovery-scheduler-trigger")
+  eval(userAndGroupProvider.isMemberOfAnyOfTheSuppliedGroups($a, "System Users"))
+then
+  $o.setSuccess(true);
+end
+```
+
+Denial (fixed inside `cp-auth-rules-filter`): no/blank `CJSCPPUID` → 401; no matching rule / non-matching caller → 403. A wrong or missing vendor media type also denies (fail-closed), never leaves the endpoint unprotected.
+
+Route this ACL change through the `rbac-auditor` agent (CLAUDE.md rule for `resources/acl/`).
+
+### 5. Service layer
+
+New `DiscoveryTriggerService`, not a method on `DiscoveryService`:
+
+```
+DiscoveryTriggerService
+  ├── DiscoveryService discoveryService       (existing, untouched)
+  └── TaskExecutor discoveryTriggerExecutor   (new)
+
+  public void trigger(DiscoveryOperation operation)
+      switch (operation) { INTRADAY -> discoveryService::runIntradayDiscovery
+                            NIGHTLY  -> discoveryService::runNightlyDiscovery }  // exhaustive, no default
+      -> wrap in logging/timing decorator -> executor.execute(wrapped) -> return
+```
+
+Separate class because `DiscoveryService`'s constructor already takes 9 dependencies — adding a `TaskExecutor` there would touch every `DiscoveryServiceTest` construction site. Exhaustive switch (no `default`) turns a future third enum value into a compile error, not a silent no-op.
+
+### 6. Fire-and-forget dispatch
+
+Dedicated, bounded `ThreadPoolTaskExecutor` in `config/DiscoveryTriggerConfig.java` (not `ShedLockConfig` — unrelated to locking):
+
+```
+@Bean("discoveryTriggerExecutor")
+ThreadPoolTaskExecutor discoveryTriggerExecutor(MdcCopyingTaskDecorator decorator)
+    corePoolSize = 1, maxPoolSize = 1
+    queueCapacity = ${cp.cdk.discovery-trigger.queue-capacity:10}
+    threadNamePrefix = "discovery-trigger-"
+    taskDecorator = decorator
+    waitForTasksToCompleteOnShutdown = true
+    awaitTerminationSeconds = ${cp.cdk.discovery-trigger.await-termination-seconds:30}
+```
+
+- **Explicit `execute(...)`, not `@Async`.** CSDK has zero `@Async` usage; `@EnableAsync` would add proxying service-wide for one call site, and self-invocation would silently make it synchronous again. Explicit injection is trivially unit-testable.
+- **Not virtual threads.** `spring.threads.virtual.enabled` defaults `false` and is unset in this repo — behaviour must not depend on that toggle.
+- **Boundedness is the only back-pressure.** One worker thread per pod caps concurrent manual runs per pod — per-JVM only, not a distributed guarantee (consistent with ADR-001).
+- **Rejection, deliberately rough:** queue full → `TaskRejectedException` → `GlobalExceptionHandler` catch-all → 500. A 429/503 is out of scope. `queue-capacity` is externalised.
+
+### 7. Correlation and MDC
+
+`RequestContextFilter` clears MDC in `finally`; under a 202 the filter unwinds before the worker runs, so a naive implementation silently loses `correlationId`.
+
+**Design:** `MdcCopyingTaskDecorator implements TaskDecorator` — captures `MDC.getCopyOfContextMap()` on the request thread at submit time (before `finally` runs), installs it on the worker, runs the delegate, clears MDC in its own `finally`. Both start/completion log records then carry the HTTP request's `correlationId`, also returned in the 202 body.
+
+### 8. Logging
+
+| Where | Level | Message |
+|---|---|---|
+| Controller, on accept | `debug` | `Discovery trigger accepted discoveryOperation={}` |
+| Worker, start | `info` | `Manual discovery run starting discoveryOperation={} trigger=manual` |
+| Worker, success | `info` | `Manual discovery run finished discoveryOperation={} trigger=manual durationMs={}` |
+| Worker, exception | `error` | `Manual discovery run failed discoveryOperation={} trigger=manual durationMs={}` + exception |
+
+`trigger=manual` and `discoveryOperation` go into MDC on the worker (promoted to JSON fields by `LogstashEncoder`) — the explicit discriminator vs. the cron path's differently-worded lines. The `error` branch is required: a failure in the surrounding code (not just per-item dispatch, which `DiscoveryService` already swallows) can still escape and must not leave the start/finish pair unterminated. Only the enum name is logged — no `CJSCPPUID`, case/court ids, hearing dates, or content.
+
+### 9. Error handling
+
+| Input | Exception | Status |
+|---|---|---|
+| Discriminator absent/null | `MethodArgumentNotValidException` (`@NotNull` + `@Valid`) | 400 |
+| Unrecognised value / malformed JSON | `HttpMessageNotReadableException` | 400 |
+| Wrong HTTP method | `HttpRequestMethodNotSupportedException` | 405 |
+
+All flow through the existing `GlobalExceptionHandler` — no new exception-handling code. The one new handling point is the worker-thread `catch (Exception)` in `DiscoveryTriggerService`: once the 202 is sent there's no response left to write to, so a post-response failure is observable only in logs — the accepted trade-off of fire-and-forget, accept-and-log.
+
+### 10. Configuration
+
+```yaml
+cp:
+  cdk:
+    discovery-trigger:
+      queue-capacity: ${CP_CDK_DISCOVERY_TRIGGER_QUEUE_CAPACITY:10}
+      await-termination-seconds: ${CP_CDK_DISCOVERY_TRIGGER_AWAIT_TERMINATION_SECONDS:30}
+```
+
+Not under `scheduler.*` — the trigger is not a scheduler.
+
+---
+
+## Testing
+
+Scoping only — Test Specs stage owns the actual scenarios.
+
+**Unit (`src/test/`)**
+
+| Target | Covers |
+|---|---|
+| `DiscoveryTriggerServiceTest` (new) | Enum routes to the correct `DiscoveryService` method; submission delegates to the injected executor (request thread doesn't run the work); an escaping exception is caught and logged, not rethrown. |
+| `DiscoverySchedulerControllerTest` (extend) | New method returns 202 + correct vendor content type, delegates once; existing tests unaffected. |
+| `MdcCopyingTaskDecoratorTest` (new) | MDC captured at decorate-time is visible in the worker; cleared after (no leakage between pooled tasks); null map handled. |
+| `DiscoveryServiceTest` (existing) | Must not change. |
+
+**Integration (`src/integrationTest/`)** — new `DiscoverySchedulerTriggerHttpLiveTest`:
+
+1. Authorised trigger → 202, body echoes the operation.
+2. `"AI search"`-only caller → 403 (the key proof the `.drl` rule binds to the right action name).
+3. No `CJSCPPUID` → 401.
+4. Invalid discriminator / missing field / malformed JSON → 400, body carries no caller-supplied value.
+5. Non-blocking: delay the WireMock hearing stub, assert 202 returns well before that delay elapses.
+6. Audit event emitted (`BrokerUtil`).
+7. Wrong/absent vendor media type → 403.
+
+**Testability obstacle:** the compose stack runs both discovery crons every 30s, which confounds any IT asserting dispatch *counts*. Assert on discriminators instead (`trigger=manual` + correlation id + the 202 contract) — no compose change needed, existing scheduler live tests stay intact.
+
+**Contract tests:** none expected — no known consumer yet.
+
+**Verify empirically:** unknown-JSON-field behaviour (CSDK's `@Primary ObjectMapper` may not match Boot's default), and JaCoCo coverage on the new `@Configuration`/`TaskDecorator` classes (easy to leave uncovered).

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/02-design.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/02-design.md
@@ -1,6 +1,6 @@
 # Design: Manual Discovery Scheduler Trigger Endpoint
 
-> **Stage 2 — Architecture & Design** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Stage 2 — Architecture & Design** · Service: `cp-case-document-knowledge-service` (CDKS)
 > **Jira: DD-43036** · Requirements: [`01-requirements.md`](./01-requirements.md) · ADRs: [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md)
 > `POST /discovery-scheduler/trigger` — enum discriminator (`INTRADAY`/`NIGHTLY`), returns `202 Accepted` immediately, dispatches the existing `DiscoveryService` operation onto a dedicated bounded executor. `DiscoveryService` itself is not touched.
 
@@ -135,7 +135,7 @@ ThreadPoolTaskExecutor discoveryTriggerExecutor(MdcCopyingTaskDecorator decorato
     awaitTerminationSeconds = ${cp.cdk.discovery-trigger.await-termination-seconds:30}
 ```
 
-- **Explicit `execute(...)`, not `@Async`.** CSDK has zero `@Async` usage; `@EnableAsync` would add proxying service-wide for one call site, and self-invocation would silently make it synchronous again. Explicit injection is trivially unit-testable.
+- **Explicit `execute(...)`, not `@Async`.** CDKS has zero `@Async` usage; `@EnableAsync` would add proxying service-wide for one call site, and self-invocation would silently make it synchronous again. Explicit injection is trivially unit-testable.
 - **Not virtual threads.** `spring.threads.virtual.enabled` defaults `false` and is unset in this repo — behaviour must not depend on that toggle.
 - **Boundedness is the only back-pressure.** One worker thread per pod caps concurrent manual runs per pod — per-JVM only, not a distributed guarantee (consistent with ADR-001).
 - **Rejection, deliberately rough:** queue full → `TaskRejectedException` → `GlobalExceptionHandler` catch-all → 500. A 429/503 is out of scope. `queue-capacity` is externalised.
@@ -208,4 +208,4 @@ Scoping only — Test Specs stage owns the actual scenarios.
 
 **Contract tests:** none expected — no known consumer yet.
 
-**Verify empirically:** unknown-JSON-field behaviour (CSDK's `@Primary ObjectMapper` may not match Boot's default), and JaCoCo coverage on the new `@Configuration`/`TaskDecorator` classes (easy to leave uncovered).
+**Verify empirically:** unknown-JSON-field behaviour (CDKS's `@Primary ObjectMapper` may not match Boot's default), and JaCoCo coverage on the new `@Configuration`/`TaskDecorator` classes (easy to leave uncovered).

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
@@ -1,6 +1,6 @@
 # User Stories: Manual Discovery Scheduler Trigger Endpoint
 
-> **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CDKS)
 > **Parent Jira: DD-43036** — each story below gets its own sub-ticket (placeholder `DD-#####` until raised).
 > Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
 > so each story is ready to paste into its Jira ticket; ADR-001/ADR-002
@@ -14,7 +14,7 @@ deployed to and verified on sandbox · Jira ticket updated with test evidence. D
 
 ## Story 1 — Release trigger operation in the API contract
 **Jira: DD-#####**
-As a **CSDK developer**, I want **`POST /discovery-scheduler/trigger` and its schemas — including
+As a **CDKS developer**, I want **`POST /discovery-scheduler/trigger` and its schemas — including
 the dedicated vendor media type — added to and released from
 `api-cp-crime-caseadmin-case-document-knowledge`**, so that **the endpoint can be implemented
 against a generated interface, not hand-scaffolded**.

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
@@ -1,0 +1,97 @@
+# User Stories: Manual Discovery Scheduler Trigger Endpoint
+
+> **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CSDK)
+> **Parent Jira: DD-43036** — each story below gets its own sub-ticket (placeholder `DD-#####` until raised).
+> Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
+> so each story is ready to paste into its Jira ticket; ADR-001/ADR-002
+> ([`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md)) are locked decisions, not reopened here.
+
+**Standard DoD (applies to every story unless noted)**: code reviewed & approved · all ACs
+covered by automated tests (unit + integration) · no critical/high Snyk findings introduced ·
+deployed to and verified on sandbox · Jira ticket updated with test evidence. Deltas only, below.
+
+---
+
+## Story 1 — Release trigger operation in the API contract
+**Jira: DD-#####**
+As a **CSDK developer**, I want **`POST /discovery-scheduler/trigger` and its schemas — including
+the dedicated vendor media type — added to and released from
+`api-cp-crime-caseadmin-case-document-knowledge`**, so that **the endpoint can be implemented
+against a generated interface, not hand-scaffolded**.
+
+**Acceptance Criteria**
+- AC-016: `version.cdk` references a released contract version with the new operation; controller implements the generated interface, no hand-scaffolded mapping.
+
+- NFR: none — schema-only change, no runtime behaviour in this repo
+- Dependency: blocks Stories 2–3; vendor media type drives the Drools action name (design §1)
+- DoD delta: contract PR reviewed & released; no breaking change to existing `Discovery Scheduler` tag
+
+## Story 2 — System-Users-only ACL rule for the trigger endpoint
+**Jira: DD-#####**
+As a **security engineer**, I want **a new Drools rule restricting the trigger action to "System
+Users" only, no "AI search" fallback**, so that **only trusted operational callers can force an
+on-demand run**.
+
+**Acceptance Criteria**
+- AC-008: `"System Users"` member → authorised.
+- AC-009: `"AI search"`-only caller → denied (403), nothing dispatched.
+- AC-010: No `CJSCPPUID` → denied (401), nothing dispatched.
+- AC-011: New Drools rule has exactly one group-membership condition — no `hasPermission`, no `or` — matching `discovery-scheduler-configuration`.
+
+- NFR: NFR-001 (AuthZ)
+- Dependency: needs Story 1's released vendor media type/action name; route through `rbac-auditor`
+  (CLAUDE.md — any `acl/` change)
+- DoD delta: `rbac-auditor` review completed for `acl/cdks-rules.drl`
+
+## Story 3 — On-demand discovery trigger endpoint (fire-and-forget dispatch)
+**Jira: DD-#####**
+As a **support/operations user (System User)**, I want **to POST a named operation
+(`INTRADAY`/`NIGHTLY`) and get an immediate `202 Accepted`**, so that **I can force a missed or
+extra discovery run without waiting for its cron, or blocking on completion**.
+
+Reuses `DiscoveryService` unchanged via new `DiscoveryTriggerService` + dedicated bounded executor
+(design §5–6, §9–10); no scheduler-lock coordination (ADR-001), fire-and-forget 202 (ADR-002).
+
+**Acceptance Criteria**
+- AC-001: Valid System User request → `202 Accepted`, operation dispatched.
+- AC-002: Wrong HTTP method → `405`, nothing dispatched.
+- AC-004 / AC-005: `INTRADAY`/`NIGHTLY` runs only its own operation, not the other's.
+- AC-006: `runIntradayDiscovery()`/`runNightlyDiscovery()` stay the single implementation, used by both cron and this endpoint.
+- AC-007: Existing intraday/nightly test suites pass unmodified.
+- AC-012–014: Missing field / unrecognised value / malformed JSON → `400` (`ErrorResponse`; malformed JSON message is `"Malformed request body"`), nothing dispatched.
+- AC-015: None of the above error bodies contain a case identifier, court reference, document content, or `CJSCPPUID`.
+- AC-017: `202` returns well before a `NIGHTLY` run could complete.
+- AC-021: Manual trigger overlapping a locked cron run behaves per ADR-001's accepted-risk position (documented, not prevented).
+- AC-022: A per-item dispatch failure doesn't stop remaining dispatches; failure is logged.
+- AC-023: An audit event exists identifying the action and its time.
+- AC-024: `gradle clean build` (incl. `integration`) passes; PMD/JaCoCo green at existing thresholds.
+- AC-025: Diff introduces no connection string, SAS token, account key, or other static credential.
+
+- Out of scope: run-status/history, cancel/pause/resume, parameterising the run, a third operation,
+  rate limiting, 409/429 on queue-full/lock-overlap (design §6, ADR-001)
+- NFR: NFR-004, NFR-005, NFR-006, NFR-008, NFR-009, NFR-012
+- Dependency: needs Story 1 released/consumed (`version.cdk` bump lands here); compiles independent
+  of Story 2 but fail-closed without it — ship together
+- DoD delta: `DiscoveryServiceTest`/existing scheduler tests pass unmodified (AC-007); `gradle
+  clean build` incl. `integration` green, PMD/JaCoCo at existing thresholds (AC-024)
+
+## Story 4 — Structured logging and correlation for manual discovery runs
+**Jira: DD-#####**
+As an **on-call engineer**, I want **each manual trigger to emit one correlated start/completion
+log pair, explicitly distinguishable from a cron run**, so that **I can trace and audit manual
+interventions without confusing them with scheduled ones**.
+
+`RequestContextFilter` clears MDC before the worker runs under a 202 — needs
+`MdcCopyingTaskDecorator` to capture MDC at submit time (design §7–8).
+
+**Acceptance Criteria**
+- AC-018: Exactly one start + one completion log record per run, both carrying the request's correlation id.
+- AC-019: Manual run distinguishable from a cron run by an explicit field, not timestamp inference.
+- AC-020: No log record from a manual run contains `CJSCPPUID`, case identifier, court reference, document content, or answer text.
+
+- NFR: NFR-002 (Logging), NFR-007 (Observability)
+- Dependency: implemented alongside Story 3's classes — split out for FR-011 traceability only,
+  not independently deployable
+- DoD delta: covers `MdcCopyingTaskDecoratorTest` and the non-blocking delayed-stub assertion
+  (design Testing item 5); manual + automated check confirms no PII/case data in any log record
+

--- a/docs/pipeline/adrs/DD-43036-manual-scheduler-trigger.md
+++ b/docs/pipeline/adrs/DD-43036-manual-scheduler-trigger.md
@@ -1,0 +1,63 @@
+# Architecture Decision Records — Manual Discovery Scheduler Trigger Endpoint
+
+> Service: `cp-case-document-knowledge-service` (CSDK) · Jira: DD-43036 · Taken at the Stage 1 → Stage 2 human gate.
+> Requirement: [`../DD-43036-manual-scheduler-trigger/`](../DD-43036-manual-scheduler-trigger/) ·
+> Requirements: [`01-requirements.md`](../DD-43036-manual-scheduler-trigger/01-requirements.md) ·
+> Design: [`02-design.md`](../DD-43036-manual-scheduler-trigger/02-design.md)
+
+---
+
+## ADR-001: Manual discovery trigger does not coordinate with the scheduler's distributed lock
+
+- **Status:** Accepted · **Date:** 2026-07-28 · **Jira:** DD-43036
+- **Artefacts:** `01-requirements.md` (NFR-004, FR-013) · `02-design.md` (§6)
+
+### Context
+
+`@SchedulerLock` sits on the **scheduler** classes (`intradayDiscoveryScheduler` PT8M/PT9M, `nightlyDiscoveryScheduler` PT1H/PT2H), not on `DiscoveryService`, which has no locking of its own. Any caller invoking `DiscoveryService` directly — including a new manual-trigger endpoint — bypasses the lock entirely, so a policy decision was unavoidable. The nightly lock can be held for up to 2 hours, and every plausible operational driver (missed-run recovery, smoke testing, support reprocessing) needs the run to happen *now*.
+
+### Decision
+
+**Run concurrently, unlocked.** `DiscoveryTriggerService` calls `runIntradayDiscovery()`/`runNightlyDiscovery()` directly, like any other caller. Duplicate dispatch if a manual trigger overlaps a live cron run is **accepted, not mitigated** — no lock semantics added, nothing on the cron path altered.
+
+### Alternatives considered
+
+- **Reject with 409 while locked** — rejected: could block a recovery tool for up to 2h; needs new lock-inspection code and a new contract response.
+- **Queue behind the lock** — rejected: unbounded wait up to 2h, new queue/expiry machinery, incompatible with ADR-002's 202 contract.
+- **Share the lock (silent skip)** — rejected as worst option: returns success while doing nothing, and requires moving `@SchedulerLock` off the schedulers.
+
+### Consequences
+
+- **Positive:** zero blast radius on the cron path (FR-005/FR-010 hold by construction); no new lock/queue/409 machinery; behaviour is unconditional and predictable.
+- **Accepted risk:** duplicate ingestion dispatch is possible if a manual trigger overlaps a cron run, or two manual triggers land on different pods simultaneously (nightly is worst case). NFR-004/AC-021 are written to describe this, not to promise its absence. Idempotency is inherited from the Task Manager/RAG layers, unchanged either way. Must be stated in the runbook and contract description.
+- **Containment (not mitigation):** a single-worker executor (`02-design.md` §6) caps the manual path at one concurrent run per pod — per-JVM only, not a distributed guarantee.
+- **Reversible:** adding a ShedLock check (or distinct lock name) inside `DiscoveryTriggerService` later is additive — no contract change, no migration.
+
+---
+
+## ADR-002: Manual discovery trigger is fire-and-forget, returning 202 Accepted
+
+- **Status:** Accepted · **Date:** 2026-07-28 · **Jira:** DD-43036
+- **Artefacts:** `01-requirements.md` (FR-012, NFR-005) · `02-design.md` (§1, §6–§9)
+
+### Context
+
+`runIntradayDiscovery()`/`runNightlyDiscovery()` are synchronous, `void`, unbounded (nightly calls the Hearing API once per hearing date at a 15s read timeout, then dispatches N Task Manager jobs), and already swallow per-item failures internally. A synchronous response would hold the connection open against an unconfirmed gateway timeout. CSDK has both precedents already: `/ingestions/start` (202, fire-and-forget) and `/ingestions/start-by-case` (200, synchronous but single-case and bounded — not comparable here). Reporting per-item outcomes would also force `DiscoveryService`'s `void` signatures to change, touching the cron path.
+
+### Decision
+
+**Fire-and-forget, `202 Accepted`**, returned once the request is authorised, validated, and dispatched onto a separate thread — never blocking on completion. **Accept-and-log only**: the 202 body confirms the operation and returns a `correlationId`; no per-item counts or run status. `DiscoveryService` signatures stay unchanged. Progress/outcome are observable only via structured logs (`INFO` start/finish, `ERROR` on failure).
+
+### Alternatives considered
+
+- **Synchronous 200, blocking** — rejected: unbounded duration risks the gateway timeout; latency would grow silently with configuration count.
+- **Synchronous 200 with per-item counts** — rejected: same timeout problem, plus forces a `DiscoveryService` signature change onto the cron path (breaches FR-005/AC-007).
+- **202 + a run-status/history endpoint** — rejected as out of scope: needs new persistence; belongs to a fresh Stage 1 if ever needed.
+- **204 No Content** — rejected: 202 is the correct semantics and allows a body carrying `correlationId`.
+
+### Consequences
+
+- **Positive:** response time independent of run duration (NFR-005 satisfied structurally); `DiscoveryService` untouched (FR-005/AC-006/AC-007 hold); consistent with the `/ingestions/start` precedent; continue-on-error behaviour inherited free.
+- **Accepted:** the caller learns nothing beyond "dispatched" — a post-202 failure is only visible in logs (mitigated by the `correlationId` in the response + an explicit `ERROR` log). A new in-process async mechanism is introduced (CSDK had none); queue exhaustion surfaces as a bare 500 — a known, deliberately unaddressed rough edge.
+- **Technical risk, mitigated in design:** `RequestContextFilter` clears MDC in `finally`, so a naive implementation would silently drop `correlationId` on every triggered run — closed by capturing MDC at submit time (`02-design.md` §7). Non-blocking behaviour needs an explicit IT (delayed-stub assertion), since nothing in the type system prevents a future change from making it synchronous again.
+- **Reversibility — effectively one-way:** moving to synchronous/per-item-counts later would break the released contract and `DiscoveryService`'s signatures. Get the contract right first time (`02-design.md` §1).

--- a/docs/pipeline/adrs/DD-43036-manual-scheduler-trigger.md
+++ b/docs/pipeline/adrs/DD-43036-manual-scheduler-trigger.md
@@ -1,6 +1,6 @@
 # Architecture Decision Records — Manual Discovery Scheduler Trigger Endpoint
 
-> Service: `cp-case-document-knowledge-service` (CSDK) · Jira: DD-43036 · Taken at the Stage 1 → Stage 2 human gate.
+> Service: `cp-case-document-knowledge-service` (CDKS) · Jira: DD-43036 · Taken at the Stage 1 → Stage 2 human gate.
 > Requirement: [`../DD-43036-manual-scheduler-trigger/`](../DD-43036-manual-scheduler-trigger/) ·
 > Requirements: [`01-requirements.md`](../DD-43036-manual-scheduler-trigger/01-requirements.md) ·
 > Design: [`02-design.md`](../DD-43036-manual-scheduler-trigger/02-design.md)
@@ -42,7 +42,7 @@
 
 ### Context
 
-`runIntradayDiscovery()`/`runNightlyDiscovery()` are synchronous, `void`, unbounded (nightly calls the Hearing API once per hearing date at a 15s read timeout, then dispatches N Task Manager jobs), and already swallow per-item failures internally. A synchronous response would hold the connection open against an unconfirmed gateway timeout. CSDK has both precedents already: `/ingestions/start` (202, fire-and-forget) and `/ingestions/start-by-case` (200, synchronous but single-case and bounded — not comparable here). Reporting per-item outcomes would also force `DiscoveryService`'s `void` signatures to change, touching the cron path.
+`runIntradayDiscovery()`/`runNightlyDiscovery()` are synchronous, `void`, unbounded (nightly calls the Hearing API once per hearing date at a 15s read timeout, then dispatches N Task Manager jobs), and already swallow per-item failures internally. A synchronous response would hold the connection open against an unconfirmed gateway timeout. CDKS has both precedents already: `/ingestions/start` (202, fire-and-forget) and `/ingestions/start-by-case` (200, synchronous but single-case and bounded — not comparable here). Reporting per-item outcomes would also force `DiscoveryService`'s `void` signatures to change, touching the cron path.
 
 ### Decision
 
@@ -58,6 +58,6 @@
 ### Consequences
 
 - **Positive:** response time independent of run duration (NFR-005 satisfied structurally); `DiscoveryService` untouched (FR-005/AC-006/AC-007 hold); consistent with the `/ingestions/start` precedent; continue-on-error behaviour inherited free.
-- **Accepted:** the caller learns nothing beyond "dispatched" — a post-202 failure is only visible in logs (mitigated by the `correlationId` in the response + an explicit `ERROR` log). A new in-process async mechanism is introduced (CSDK had none); queue exhaustion surfaces as a bare 500 — a known, deliberately unaddressed rough edge.
+- **Accepted:** the caller learns nothing beyond "dispatched" — a post-202 failure is only visible in logs (mitigated by the `correlationId` in the response + an explicit `ERROR` log). A new in-process async mechanism is introduced (CDKS had none); queue exhaustion surfaces as a bare 500 — a known, deliberately unaddressed rough edge.
 - **Technical risk, mitigated in design:** `RequestContextFilter` clears MDC in `finally`, so a naive implementation would silently drop `correlationId` on every triggered run — closed by capturing MDC at submit time (`02-design.md` §7). Non-blocking behaviour needs an explicit IT (delayed-stub assertion), since nothing in the type system prevents a future change from making it synchronous again.
 - **Reversibility — effectively one-way:** moving to synchronous/per-item-counts later would break the released contract and `DiscoveryService`'s signatures. Get the contract right first time (`02-design.md` §1).


### PR DESCRIPTION
 What

  Adds the User Story pipeline artefact for DD-43036 (Manual Discovery Scheduler Trigger Endpoint) and refreshes CLAUDE.md to reflect the current plugin-based SDLC pipeline setup.

  Why

  Story-writer stage output for DD-43036 needs to be captured under the versioned pipeline docs convention before test-spec and implementation work can begin. CLAUDE.md had drifted from the plugin's actual
  structure (paths, agent references, artefact conventions) and needed realignment.

  Changes

  - Added docs/pipeline/DD-43036-manual-scheduler-trigger/ artefacts: 00-input-brief.md, 01-requirements.md, 02-design.md, 03-stories.md, and adrs/DD-43036-manual-scheduler-trigger.md
  - Split into 4 stories: release trigger operation in the API contract, System-Users-only ACL rule for the trigger endpoint, on-demand discovery trigger endpoint (fire-and-forget dispatch), and structured
  logging/correlation for manual discovery runs
  - Updated CLAUDE.md:
    - Distinguished CSDK-local context docs (.claude/context/) from plugin-provided ones ($PLUGIN/context/), added coding-standards.md to the on-demand load list
    - Reworked the pipeline stage table to reference plugin agent names and the two local overrides (implementation, ci-orchestrator), with a note on keeping them in sync with the plugin
    - Expanded the auxiliary agents/skills table (added research, test-analyzer, api-contract-check, review-checklist, write-acceptance-criteria, springboot-service-from-template) and the "not applicable" list
    - Documented the per-ticket artefact folder convention (<JIRA-TICKET>-<slug>/00-05 + matching ADR file) replacing the old flat docs/pipeline/ layout
    - Added a hard rule noting the plugin's block-pii/block-secrets/guard-bash/guard-paths hooks enforce the PII and Managed-Identity rules automatically

  No production code, test, or build changes in this branch.
