### PR TITLE
[DD-43084] Persist RAG transactionId on generated answers

### DIFF
--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/00-input-brief.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/00-input-brief.md
@@ -1,0 +1,38 @@
+# 00 — Input Brief
+
+> Raw, unstructured input as given by the requester. Jira ticket: **DD-43084**
+> (https://tools.hmcts.net/jira/browse/DD-43084).
+
+## Brief (verbatim)
+
+As per DD-43084: currently when we call the RAG service from `GenerateAnswerForQueryTask` we get
+back a `transactionId`, but that same `transactionId` is not getting persisted in any of the
+answers tables. Come up with requirements, design, and all other pipeline stages (mirroring the
+approach used for DD-43036, manual scheduler trigger), and a plan to store the `transactionId`
+(answer-related) in the answers table(s).
+
+## Source
+
+Jira ticket DD-43084 (title/description not fetched — no Jira MCP/tool access in this session;
+the brief above is the requester's own restatement of the ticket in conversation). The ticket
+number and one-line problem statement should be verified against Jira directly before this
+requirement is taken to the Story stage — see Open Question OQ-001 in `01-requirements.md`.
+
+## Ground truth gathered from the codebase before drafting requirements
+
+- `GenerateAnswerForQueryTask` (`jobmanager/queryflow/GenerateAnswerForQueryTask.java`) calls
+  `documentInformationSummarisedAsynchronouslyApi.answerUserQueryAsync(request)`, reads
+  `transactionId` off the response, and hands it forward only via Task Manager job data
+  (`CTX_RAG_TRANSACTION_ID` = `"ragTransactionId"`), addressed to the next task.
+- `CheckStatusOfAnswerGenerationTask` reads that same `ragTransactionId` back out of job data,
+  uses it only to (a) poll `answerUserQueryStatus(transactionId, ...)` and (b) as a log
+  correlation value. Once the poll succeeds, it calls one of four upsert methods —
+  `AnswerGenerationService.upsertAnswer(...)`, `CaseLevelLatestDocumentAnswerService.upsert(...)`,
+  `CaseLevelAllDocumentsAnswerService.upsert(...)`, `DefendantAnswerService.upsert(...)` — and the
+  `transactionId` variable is dropped; none of the four method signatures accept it, and none of
+  the four target tables (`answers`, `case_level_latest_doc_answers`,
+  `case_level_all_documents_answers`, `defendant_answers`) have a column for it.
+- This is a direct instance of the CDKS hard rule "do not drop RAG response fields" —
+  `.claude/context/cdks-context.md` already calls out `doc_id`/`llm_input` as fields that must be
+  preserved; `transactionId` is the same category of RAG-provenance field and is currently being
+  silently discarded at the last step before persistence.

--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/01-requirements.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/01-requirements.md
@@ -1,0 +1,101 @@
+# Requirements: Persist RAG `transactionId` on Answer Records
+
+> **Stage 1 — Requirements** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43084**
+> Gate decisions (column placement, nullability, API scope) are folded in below — see
+> `02-design.md` and [`adrs/DD-43084-persist-rag-transaction-id.md`](../adrs/DD-43084-persist-rag-transaction-id.md) (ADR-001/002).
+
+---
+
+## Context
+
+CDKS generates an answer asynchronously: `GenerateAnswerForQueryTask` calls the RAG service's
+`answerUserQueryAsync` endpoint and receives a `transactionId`; that id is forwarded via Task
+Manager job data to `CheckStatusOfAnswerGenerationTask`, which polls RAG's
+`answerUserQueryStatus(transactionId, ...)` until the answer is ready, then persists it into one of
+four tables depending on `QueryLevel` — `answers` (default), `case_level_latest_doc_answers`
+(`CASE`), `case_level_all_documents_answers` (`CASE_ALL_DOCUMENTS`), `defendant_answers`
+(`DEFENDANT`). Today the `transactionId` is used only to poll and to correlate log lines; it is
+discarded before any of the four persistence calls, and none of the four tables have a column for
+it.
+
+This is the same class of problem the CDKS hard rule "do not drop RAG response fields" already
+covers for `doc_id`/`llm_input` (`.claude/context/cdks-context.md`) — `transactionId` is
+RAG-provenance data being silently lost at the last step before persistence, undermining the
+traceability CDKS is meant to guarantee for AI-generated answers.
+
+**Note on source:** this requirement is derived from the requester's own restatement of Jira
+DD-43084 in conversation; the ticket itself was not fetched (no Jira access in this session — see
+OQ-001). Treat FR/AC below as the working scope until confirmed against the ticket text.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | `CheckStatusOfAnswerGenerationTask` passes its already-resolved `transactionId` into whichever of the four upsert calls it makes for a successfully generated answer (`ANSWER_GENERATED`). |
+| FR-002 | Each of `answers`, `case_level_latest_doc_answers`, `case_level_all_documents_answers`, `defendant_answers` gains a `rag_transaction_id UUID NULL` column via one new, append-only Flyway migration (`V1012`). |
+| FR-003 | Each of the four upsert methods (`AnswerGenerationService.upsertAnswer`, `CaseLevelLatestDocumentAnswerService.upsert`, `CaseLevelAllDocumentsAnswerService.upsert`, `DefendantAnswerService.upsert`) accepts the transaction id and writes it on both `INSERT` and `ON CONFLICT ... DO UPDATE SET` — a re-upsert of an existing version always reflects the transaction that most recently produced it, never a stale one. |
+| FR-004 | `TaskUtils.buildAnswerParams` (shared by `AnswerGenerationService`) is extended with the new parameter; no duplicate parameter-building logic is introduced. |
+| FR-005 | No backfill: rows written before this change, and any `ANSWER_GENERATION_FAILED` attempt (never persisted, unchanged by this ticket), show `rag_transaction_id IS NULL`. |
+| FR-006 | No API/contract change: `AnswerResponse`, `AnswerWithLlmResponse`, `AnswersResponse`, `AnswerMapper`, and `version.cdk` are unchanged (ADR-002) — persistence only. |
+| FR-007 | The read-side JPA entities that map these tables (`Answer`; `BaseAnswer`, inherited by `CaseLevelAllDocumentsAnswer` and — via `DocumentAnswer` — `CaseLevelLatestDocumentAnswer`/`DefendantAnswer`) gain a mapped `ragTransactionId` field so each entity accurately reflects its table, even though no mapper surfaces it externally yet. |
+| FR-008 | `case_query_status` is untouched — it is a current-state pointer per `(case_id, query_id)`, not a per-version record, and is out of scope (ADR-001). |
+
+**Out of scope:** exposing `transactionId` via any GET response, a new lookup-by-transaction-id
+endpoint, backfilling historic rows, changing `case_query_status` or its trigger, changing the
+retry/failure path, any change to `GenerateAnswerForQueryTask` itself (it already forwards the
+value correctly today — the gap is entirely downstream).
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Data protection / traceability | `transactionId` is an opaque RAG-issued UUID, not PII; safe to persist and already safe to log today. Storing it strengthens, not weakens, CDKS's data-protection/traceability posture. |
+| NFR-002 | Migration safety | `ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL — no table rewrite, no lock escalation, regardless of current row counts in `answers`/`defendant_answers`/etc. |
+| NFR-003 | Backward compatibility | No change to any existing GET response shape, SQL read path, or the `answers_after_insert` trigger; existing consumers of the Answers API are unaffected. |
+| NFR-004 | Testability | Unit test coverage for all four service classes, `TaskUtils`, and `CheckStatusOfAnswerGenerationTask`; `integrationTest` coverage asserting the column is actually populated end-to-end via the existing RAG WireMock stub. `gradle integration` passes. |
+| NFR-005 | Code quality | PMD/JaCoCo unmodified thresholds; change is mechanical parameter-threading, no new suppressions expected. |
+| NFR-006 | Migration governance | The new `V1012__*.sql` is routed through the `migration-reviewer` agent per CLAUDE.md's hard rule for any change under `db/migration`. |
+| NFR-007 | Platform | Java 25 / Spring Boot 4.0.5 / Gradle 9; existing `NamedParameterJdbcTemplate` raw-SQL pattern in the four services is preserved, not replaced with JPA writes. |
+
+---
+
+## Acceptance Criteria
+
+**Persistence — one per query level**
+- AC-001: A successfully generated `CASE`-level answer persists `rag_transaction_id` equal to the polled transaction id, in `case_level_latest_doc_answers`.
+- AC-002: Same for `CASE_ALL_DOCUMENTS` → `case_level_all_documents_answers`.
+- AC-003: Same for `DEFENDANT` → `defendant_answers`.
+- AC-004: Same for `null`/default level → `answers`.
+
+**Upsert correctness**
+- AC-005: Re-upserting an existing `(case_id, query_id[, defendant_id], version)` row updates `rag_transaction_id` to the new value via `EXCLUDED.rag_transaction_id`, never leaving a stale id from a prior transaction.
+- AC-006: Rows that predate this migration, or any failed-generation attempt, show `rag_transaction_id IS NULL` — no error, no backfill attempted.
+
+**No API surface change**
+- AC-007: `GET /cases/{caseId}/queries/{queryId}/answers/with-llm`, `.../answers/list`, and the `/v2/...` answers endpoints return an unchanged response shape — no new field, confirmed by the existing `AnswersHttpLiveTest` assertions passing unmodified.
+- AC-008: `AnswerMapper` output and `version.cdk` are unchanged.
+
+**Migration & tests**
+- AC-009: `V1012__*.sql` only adds nullable columns (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS rag_transaction_id UUID`) across the four tables — no rename, no drop, no data rewrite — and is reviewed by `migration-reviewer`.
+- AC-010: `AnswerGenerationServiceTest`, `CaseLevelLatestDocumentAnswerServiceTest`, `CaseLevelAllDocumentsAnswerServiceTest`, `DefendantAnswerServiceTest`, `CheckStatusOfAnswerGenerationTaskTest` compile and pass with updated signatures.
+- AC-011: New/updated unit test assertions capture the `MapSqlParameterSource` passed to each `UPSERT_SQL` and confirm `rag_transaction_id` equals the transaction id supplied by the caller.
+- AC-012: `gradle clean build` (incl. `integration`) passes; PMD/JaCoCo green at existing thresholds.
+- AC-013: Diff introduces no PII, case content, court reference, or `CJSCPPUID` into migrations, tests, or fixtures.
+
+---
+
+## Open Questions
+
+- **OQ-001:** The Jira ticket DD-43084 itself was not fetched in this session (no Jira/Atlassian
+  tool access) — confirm the ticket's literal text matches this restated scope (persist-only,
+  all four answer tables, no API exposure) before moving past the Story stage. If the ticket asks
+  for API exposure or a support-facing lookup endpoint, ADR-002's boundary needs revisiting.
+- **OQ-002:** Confirm no other consumer (e.g. a reporting/BI job, a data export) reads these four
+  tables directly and would need to be told about the new nullable column ahead of time — none
+  found in this repo via `grep`, but CDKS's `answers` tables may be queried from outside this
+  codebase.

--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/02-design.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/02-design.md
@@ -1,0 +1,226 @@
+# Design: Persist RAG `transactionId` on Answer Records
+
+> **Stage 2 — Architecture & Design** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43084** · Requirements: [`01-requirements.md`](./01-requirements.md) · ADRs: [`adrs/DD-43084-persist-rag-transaction-id.md`](../adrs/DD-43084-persist-rag-transaction-id.md)
+> Add `rag_transaction_id UUID NULL` to all four answer tables (`V1012`); thread the value
+> `CheckStatusOfAnswerGenerationTask` already resolves through to each of the four upsert calls.
+> No API/contract change, no new endpoint, no ACL change.
+
+---
+
+## Detailed Design
+
+### 1. Migration (this repo — no external contract dependency)
+
+**File:** `src/main/resources/db/migration/V1012__add_rag_transaction_id_to_answers.sql` (next
+version after `V1011`).
+
+```sql
+ALTER TABLE answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version (nullable — not backfilled for rows written before this column existed).';
+
+ALTER TABLE case_level_latest_doc_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN case_level_latest_doc_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';
+
+ALTER TABLE case_level_all_documents_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN case_level_all_documents_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';
+
+ALTER TABLE defendant_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN defendant_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';
+```
+
+- Plain `UUID NULL` — no `NOT NULL`, no `DEFAULT`, no index. `ADD COLUMN` of a nullable column
+  with no default is a metadata-only operation on PostgreSQL 16 (no table rewrite), matching
+  NFR-002.
+- No index added: this ticket's driver is traceability-on-write, not a query pattern of
+  "look up an answer by transaction id" — nothing in this repo needs that access path today (see
+  `01-requirements.md` out-of-scope). Adding one later is a separate, independent, additive
+  migration if a lookup need materialises.
+- `case_query_status` is not touched (ADR-001) — it is a current-pointer table, not a
+  per-version one.
+- Route through `migration-reviewer` per CLAUDE.md's hard rule for any `db/migration` change
+  (AC-009).
+
+### 2. Files touched
+
+| File | Change |
+|---|---|
+| `db/migration/V1012__add_rag_transaction_id_to_answers.sql` *(new)* | Adds the column to all four tables. |
+| `jobmanager/queryflow/CheckStatusOfAnswerGenerationTask.java` | Pass `transactionId` into each of the four upsert calls in the `switch (level)` block. |
+| `services/AnswerGenerationService.java` | `upsertAnswer(...)` gains a `UUID transactionId` param; `SQL_UPSERT_ANSWER` inserts/updates `rag_transaction_id`. |
+| `services/CaseLevelLatestDocumentAnswerService.java` | `upsert(...)` gains the param; `UPSERT_SQL` updated. |
+| `services/CaseLevelAllDocumentsAnswerService.java` | `upsert(...)` gains the param; `UPSERT_SQL` updated. |
+| `services/DefendantAnswerService.java` | `upsert(...)` gains the param; `UPSERT_SQL` updated. |
+| `util/TaskUtils.java` | `buildAnswerParams(...)` gains the param and adds it to the returned `MapSqlParameterSource`. |
+| `domain/Answer.java` | New `@Column(name = "rag_transaction_id") private UUID ragTransactionId;` (flat entity, doesn't extend `BaseAnswer`). |
+| `domain/BaseAnswer.java` | New `@Column(name = "rag_transaction_id") protected UUID ragTransactionId;` (inherited by `CaseLevelAllDocumentsAnswer` directly, and by `DocumentAnswer` → `CaseLevelLatestDocumentAnswer`/`DefendantAnswer`). |
+
+**Not changed:** `GenerateAnswerForQueryTask.java` (already forwards `transactionId` correctly —
+the gap is entirely downstream), `case_query_status` / `trg_answers_after_insert`, any controller,
+`AnswerMapper`, any OpenAPI model, `version.cdk`, `acl/cdks-rules.drl`, any existing migration.
+
+### 3. `CheckStatusOfAnswerGenerationTask` — threading the value through
+
+`transactionId` is already resolved as a `UUID` at the top of `execute(...)` (line 74 today). The
+only change is passing it into the four existing calls inside the `switch (level)` block:
+
+```java
+switch (level) {
+    case QueryLevel.CASE:
+        caseLevelLatestDocumentAnswerService.upsert(
+                caseId, queryId, answerResponseBody.getLlmResponse(), llmInputJson, documentId, transactionId);
+        break;
+    case QueryLevel.CASE_ALL_DOCUMENTS:
+        caseLevelAllDocumentsAnswerService.upsert(
+                caseId, queryId, answerResponseBody.getLlmResponse(), llmInputJson, transactionId);
+        break;
+    case QueryLevel.DEFENDANT:
+        defendantAnswerService.upsert(
+                caseId, queryId, defendantId, answerResponseBody.getLlmResponse(), llmInputJson, documentId, transactionId);
+        break;
+    case null, default:
+        answerGenerationService.upsertAnswer(
+                caseId, queryId, answerResponseBody.getLlmResponse(), llmInputJson, documentId, transactionId);
+        break;
+}
+```
+
+No other logic in this task changes — retry handling, the `ANSWER_GENERATION_FAILED` branch, and
+the polling call are all untouched.
+
+### 4. Service-layer changes (pattern is identical across all four)
+
+Example — `CaseLevelAllDocumentsAnswerService` (the simplest of the four, no `doc_id`):
+
+```java
+private static final String UPSERT_SQL = """
+    INSERT INTO case_level_all_documents_answers
+    (case_id, query_id, version, created_at, answer, llm_input, rag_transaction_id)
+    VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :rag_transaction_id)
+    ON CONFLICT (case_id, query_id, version) DO UPDATE SET
+        answer = EXCLUDED.answer,
+        llm_input = EXCLUDED.llm_input,
+        rag_transaction_id = EXCLUDED.rag_transaction_id,
+        created_at = EXCLUDED.created_at
+""";
+
+@Transactional
+public void upsert(final UUID caseId, final UUID queryId, final String answer,
+                   final String llmInput, final UUID ragTransactionId) {
+    final int version = getVersionNumber(caseId, queryId);
+    final MapSqlParameterSource params = new MapSqlParameterSource()
+            .addValue("case_id", caseId)
+            .addValue("query_id", queryId)
+            .addValue("version", version)
+            .addValue("answer", answer)
+            .addValue("llm_input", llmInput)
+            .addValue("rag_transaction_id", ragTransactionId);
+    jdbc.update(UPSERT_SQL, params);
+    // ... case_query_status update unchanged
+}
+```
+
+`CaseLevelLatestDocumentAnswerService` and `DefendantAnswerService` follow the same shape, adding
+`rag_transaction_id` alongside their existing `doc_id` column. `AnswerGenerationService` instead
+extends the shared `TaskUtils.buildAnswerParams(...)` helper:
+
+```java
+// TaskUtils.java
+public static MapSqlParameterSource buildAnswerParams(final UUID caseId, final UUID queryId,
+        final Integer version, final String answer, final String llmInput,
+        final UUID documentId, final UUID ragTransactionId) {
+    return new MapSqlParameterSource()
+            .addValue("case_id", caseId)
+            .addValue("query_id", queryId)
+            .addValue("version", version)
+            .addValue("answer", answer)
+            .addValue("llm_input", llmInput)
+            .addValue("doc_id", documentId)
+            .addValue("rag_transaction_id", ragTransactionId);
+}
+```
+
+`buildCaseStatusParams` / `GLOBAL_UPDATE_CASE_QUERY_STATUS` / `case_query_status` are **not**
+touched — that table has no per-version transaction concept (ADR-001).
+
+`SQL_UPSERT_ANSWER` in `AnswerGenerationService` gets the same `rag_transaction_id` column added
+to its `INSERT`/`ON CONFLICT` clauses as the example above.
+
+### 5. Read-side entities (JPA)
+
+Two edits keep the four JPA entities in sync with their tables, even though nothing maps this
+field out to the API yet (ADR-002):
+
+```java
+// BaseAnswer.java — inherited by CaseLevelAllDocumentsAnswer, DocumentAnswer
+// (→ CaseLevelLatestDocumentAnswer, DefendantAnswer)
+@Column(name = "rag_transaction_id")
+protected UUID ragTransactionId;
+```
+
+```java
+// Answer.java — flat entity, does not extend BaseAnswer
+@Column(name = "rag_transaction_id")
+private UUID ragTransactionId;
+```
+
+`AnswerMapper`, `AnswerResponse`, `AnswerWithLlmResponse`, `AnswersResponse` are all left
+unchanged (ADR-002) — this is a read-side data-completeness change only, not an API change.
+
+### 6. Error handling
+
+No new error paths. If `transactionId` were ever `null` at the call site (it can't be today —
+`CheckStatusOfAnswerGenerationTask` already dereferences it via `.toString()` for the status-poll
+call earlier in the same method, so a `null` would already have thrown an NPE and been caught by
+the task's existing `catch (Exception ex) { return retry(...); }` before reaching the upsert
+calls), the `MapSqlParameterSource.addValue("rag_transaction_id", null)` path is safe — Postgres
+just stores `NULL`, consistent with FR-005/FR-006's "no backfill" nullable design.
+
+---
+
+## Testing
+
+Scoping only — Test Specs stage owns the actual scenarios.
+
+**Unit (`src/test/`)**
+
+| Target | Covers |
+|---|---|
+| `AnswerGenerationServiceTest` (extend) | `upsertAnswer(..., transactionId)` writes `rag_transaction_id` into the captured `MapSqlParameterSource`; existing version/status assertions unaffected. |
+| `CaseLevelLatestDocumentAnswerServiceTest` / `CaseLevelAllDocumentsAnswerServiceTest` / `DefendantAnswerServiceTest` (extend) | Same pattern per table — capture `MapSqlParameterSource`, assert `rag_transaction_id` equals the value passed in. |
+| `CheckStatusOfAnswerGenerationTaskTest` (extend) | For each `QueryLevel` branch (`CASE`, `CASE_ALL_DOCUMENTS`, `DEFENDANT`, `null`/default), verify the corresponding service's upsert method is invoked with the transaction id parsed from job data — not a null or hardcoded value. |
+| `TaskUtilsTest` (new or extend, if one exists — none found; create `TaskUtilsTest` if this is its first dedicated test) | `buildAnswerParams(...)` includes `rag_transaction_id` in the returned `MapSqlParameterSource`. |
+
+**Integration (`src/integrationTest/`)** — extend the existing async-answer WireMock flow (stubs
+already present: `answer-user-query-async.json` → `answer_user_query_async_response.json`
+containing a fixed `transactionId`; `retrieve_answers_for_transactionId.json` →
+`answer_for_transaction_response.json` for the `ANSWER_GENERATED` status poll):
+
+1. Drive a query through to a generated answer (however the existing suite triggers
+   `GenerateAnswerForQueryTask`/`CheckStatusOfAnswerGenerationTask` today, if such an end-to-end
+   trigger exists in `src/integrationTest/`; otherwise seed job data directly and invoke the task
+   bean, mirroring how `AnswersHttpLiveTest` seeds `answers` directly via JDBC).
+2. Query the relevant answer table directly via JDBC and assert `rag_transaction_id` equals the
+   fixed transaction id from the WireMock fixture (`c44576d4-ee3a-436e-b042-e867747171da`).
+3. Re-run the same (case, query, version) through the flow a second time (simulating an upsert)
+   with a different WireMock-stubbed transaction id and assert the column is overwritten, not
+   left stale (AC-005).
+4. `AnswersHttpLiveTest` — run unmodified; assert its existing response-body assertions still pass
+   with no new field appearing (AC-007), i.e. add no new assertions there, just confirm the
+   existing suite is green.
+
+**Contract tests:** none — no contract change (ADR-002); `pactVerificationTest` unaffected.
+
+**Verify empirically:** confirm whether any test infrastructure already drives
+`CheckStatusOfAnswerGenerationTask` end-to-end via HTTP/JobManager in `src/integrationTest`, or
+whether the task needs to be invoked directly as a Spring bean in the new IT — this determines
+whether step 1 above is a new IT class or an extension of an existing one, and should be resolved
+at Test Specs stage before authoring tests.

--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/03-stories.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/03-stories.md
@@ -1,0 +1,78 @@
+# User Stories: Persist RAG `transactionId` on Answer Records
+
+> **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Parent Jira: DD-43084** — each story below gets its own sub-ticket (placeholder `DD-#####` until raised).
+> Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
+> so each story is ready to paste into its Jira ticket; ADR-001/ADR-002
+> ([`adrs/DD-43084-persist-rag-transaction-id.md`](../adrs/DD-43084-persist-rag-transaction-id.md)) are locked decisions, not reopened here.
+
+**Standard DoD (applies to every story unless noted)**: code reviewed & approved · all ACs
+covered by automated tests (unit + integration) · no critical/high Snyk findings introduced ·
+deployed to and verified on sandbox · Jira ticket updated with test evidence. Deltas only, below.
+
+---
+
+## Story 1 — Add `rag_transaction_id` column to all four answer tables
+**Jira: DD-#####**
+As a **CDKS developer**, I want **a new, append-only Flyway migration (`V1012`) that adds a
+nullable `rag_transaction_id UUID` column to `answers`, `case_level_latest_doc_answers`,
+`case_level_all_documents_answers`, and `defendant_answers`**, so that **the application layer has
+somewhere to persist the RAG transaction id, with zero risk to existing data or existing reads**.
+
+**Acceptance Criteria**
+- AC-006: Rows that predate this migration, or any failed-generation attempt, show `rag_transaction_id IS NULL` — no error, no backfill attempted.
+- AC-009: `V1012__*.sql` only adds nullable columns (`ALTER TABLE ... ADD COLUMN IF NOT EXISTS rag_transaction_id UUID`) across the four tables — no rename, no drop, no data rewrite — and is reviewed by `migration-reviewer`.
+
+- NFR: NFR-002 (migration safety), NFR-006 (migration governance)
+- Dependency: blocks Story 2 (nothing to write to until the column exists); independently
+  deployable/reversible on its own — a no-op until Story 2 lands
+- DoD delta: `migration-reviewer` review completed for `V1012__add_rag_transaction_id_to_answers.sql`
+
+## Story 2 — Thread `transactionId` through the four answer-persistence paths
+**Jira: DD-#####**
+As a **support/ops engineer investigating an AI-generated answer**, I want **every successfully
+generated answer to record the RAG `transactionId` that produced it, for every query level**, so
+that **I can trace any stored answer back to the exact upstream RAG call, closing the "RAG
+response field silently dropped" gap this ticket exists to fix**.
+
+Reuses the `transactionId` `CheckStatusOfAnswerGenerationTask` already resolves today (design
+§3–§4); no new RAG call, no new job-data key, no change to `GenerateAnswerForQueryTask`.
+
+**Acceptance Criteria**
+- AC-001: A successfully generated `CASE`-level answer persists `rag_transaction_id` equal to the polled transaction id, in `case_level_latest_doc_answers`.
+- AC-002: Same for `CASE_ALL_DOCUMENTS` → `case_level_all_documents_answers`.
+- AC-003: Same for `DEFENDANT` → `defendant_answers`.
+- AC-004: Same for `null`/default level → `answers`.
+- AC-005: Re-upserting an existing `(case_id, query_id[, defendant_id], version)` row updates `rag_transaction_id` to the new value via `EXCLUDED.rag_transaction_id`, never leaving a stale id from a prior transaction.
+- AC-010: `AnswerGenerationServiceTest`, `CaseLevelLatestDocumentAnswerServiceTest`, `CaseLevelAllDocumentsAnswerServiceTest`, `DefendantAnswerServiceTest`, `CheckStatusOfAnswerGenerationTaskTest` compile and pass with updated signatures.
+- AC-011: New/updated unit test assertions capture the `MapSqlParameterSource` passed to each `UPSERT_SQL` and confirm `rag_transaction_id` equals the transaction id supplied by the caller.
+- AC-012: `gradle clean build` (incl. `integration`) passes; PMD/JaCoCo green at existing thresholds.
+- AC-013: Diff introduces no PII, case content, court reference, or `CJSCPPUID` into migrations, tests, or fixtures.
+
+- Out of scope: exposing the value via any API response, a lookup-by-transaction-id endpoint,
+  backfilling historic rows, any change to `case_query_status` or `GenerateAnswerForQueryTask`
+  (design §1, §3, ADR-001)
+- NFR: NFR-001, NFR-003, NFR-004, NFR-005, NFR-007
+- Dependency: needs Story 1's column to exist first; ships together with Story 1 in practice since
+  neither is independently useful
+- DoD delta: integration test extended against the existing async-RAG WireMock stub
+  (`answer_user_query_async_response.json`) asserting the persisted column value end-to-end
+  (design Testing items 1–3); `AnswersHttpLiveTest` re-run unmodified to confirm no response-shape
+  regression (AC-007)
+
+## Story 3 — Keep the read-side JPA entities in sync with the new column
+**Jira: DD-#####**
+As a **CDKS developer**, I want **`Answer`, `BaseAnswer` (and its subclasses) to expose a mapped
+`ragTransactionId` field**, so that **the entity model doesn't silently drift from the table it
+maps, ready for a future API-exposure change without another schema audit**.
+
+**Acceptance Criteria**
+- AC-007: `GET /cases/{caseId}/queries/{queryId}/answers/with-llm`, `.../answers/list`, and the `/v2/...` answers endpoints return an unchanged response shape — no new field, confirmed by the existing `AnswersHttpLiveTest` assertions passing unmodified.
+- AC-008: `AnswerMapper` output and `version.cdk` are unchanged.
+
+- Out of scope: any mapper/DTO/contract change (ADR-002) — this story is entity-only
+- NFR: NFR-003 (backward compatibility)
+- Dependency: needs Story 1's column; independent of Story 2 (read-side vs. write-side), can ship
+  in the same PR as Story 2 for review convenience but is logically separable
+- DoD delta: confirm via `AnswersHttpLiveTest` (unmodified) that adding the entity field alone,
+  with no mapper change, produces zero response-body diff

--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/03-stories.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/03-stories.md
@@ -1,7 +1,7 @@
 # User Stories: Persist RAG `transactionId` on Answer Records
 
 > **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CDKS)
-> **Parent Jira: DD-43084** — each story below gets its own sub-ticket (placeholder `DD-#####` until raised).
+> **Parent Jira: DD-43084** — each story below has its own sub-ticket, raised as DD-43104/DD-43105/DD-43106.
 > Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
 > so each story is ready to paste into its Jira ticket; ADR-001/ADR-002
 > ([`adrs/DD-43084-persist-rag-transaction-id.md`](../adrs/DD-43084-persist-rag-transaction-id.md)) are locked decisions, not reopened here.
@@ -13,7 +13,7 @@ deployed to and verified on sandbox · Jira ticket updated with test evidence. D
 ---
 
 ## Story 1 — Add `rag_transaction_id` column to all four answer tables
-**Jira: DD-#####**
+**Jira: [DD-43104](https://tools.hmcts.net/jira/browse/DD-43104)**
 As a **CDKS developer**, I want **a new, append-only Flyway migration (`V1012`) that adds a
 nullable `rag_transaction_id UUID` column to `answers`, `case_level_latest_doc_answers`,
 `case_level_all_documents_answers`, and `defendant_answers`**, so that **the application layer has
@@ -29,7 +29,7 @@ somewhere to persist the RAG transaction id, with zero risk to existing data or 
 - DoD delta: `migration-reviewer` review completed for `V1012__add_rag_transaction_id_to_answers.sql`
 
 ## Story 2 — Thread `transactionId` through the four answer-persistence paths
-**Jira: DD-#####**
+**Jira: [DD-43105](https://tools.hmcts.net/jira/browse/DD-43105)**
 As a **support/ops engineer investigating an AI-generated answer**, I want **every successfully
 generated answer to record the RAG `transactionId` that produced it, for every query level**, so
 that **I can trace any stored answer back to the exact upstream RAG call, closing the "RAG
@@ -61,7 +61,7 @@ Reuses the `transactionId` `CheckStatusOfAnswerGenerationTask` already resolves 
   regression (AC-007)
 
 ## Story 3 — Keep the read-side JPA entities in sync with the new column
-**Jira: DD-#####**
+**Jira: [DD-43106](https://tools.hmcts.net/jira/browse/DD-43106)**
 As a **CDKS developer**, I want **`Answer`, `BaseAnswer` (and its subclasses) to expose a mapped
 `ragTransactionId` field**, so that **the entity model doesn't silently drift from the table it
 maps, ready for a future API-exposure change without another schema audit**.

--- a/docs/pipeline/DD-43084-persist-rag-transaction-id/04-test-specs.md
+++ b/docs/pipeline/DD-43084-persist-rag-transaction-id/04-test-specs.md
@@ -1,0 +1,168 @@
+# Test Specs: Persist RAG `transactionId` on Answer Records
+
+> **Stage 4 — Test Specs** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43084** · Stories: [`03-stories.md`](./03-stories.md) · Design: [`02-design.md`](./02-design.md)
+> Written retrospectively against the code actually merged (implementation ran ahead of this
+> artefact for this ticket) — every scenario below names the real test class/method that proves
+> it, so this doc stays a traceability map rather than an aspirational spec. Where a scenario is
+> specified but not yet automated at the stated tier, that's called out explicitly (no silent
+> gaps) rather than implied as done.
+
+---
+
+## Story 1 — Add `rag_transaction_id` column to all four answer tables
+
+**Scenario 1.1 — Migration is additive and idempotent**
+- **Given** a database already at `V1011`
+- **When** Flyway applies `V1012__add_rag_transaction_id_to_answers.sql`
+- **Then** `answers`, `case_level_latest_doc_answers`, `case_level_all_documents_answers`, and
+  `defendant_answers` each gain a nullable `rag_transaction_id UUID` column, no existing row is
+  rewritten or loses data, and re-running the migration (`ADD COLUMN IF NOT EXISTS`) is a no-op.
+- **Proof:** every Testcontainers-backed Spring context test in `src/test/` (e.g.
+  `CaseDocumentRepositoryTest`, `QueryVersionRepositoryTest`, `JobManagerConfigTest`) boots against
+  a fresh Postgres 16 container and runs the full migration chain including `V1012` on every
+  `./gradlew test` run — a broken or non-idempotent migration would fail context startup for all
+  of them. Confirmed green.
+
+**Scenario 1.2 — Pre-existing rows are left `NULL`, not backfilled**
+- **Given** an `answers` row written before this migration
+- **When** `V1012` runs
+- **Then** that row's `rag_transaction_id` is `NULL`, and no error occurs from the absence of a
+  value to backfill.
+- **Proof:** covered implicitly by 1.1 (Flyway's `ADD COLUMN` with no `DEFAULT`/backfill statement
+  cannot fail this way) and explicitly disclaimed in FR-005/AC-006. No dedicated automated
+  assertion exists for this specific case today — reasonable to add only if a future change
+  introduces a backfill path and this invariant needs re-guarding.
+
+---
+
+## Story 2 — Thread `transactionId` through the four answer-persistence paths
+
+**Scenario 2.1 — `CASE` level: transaction id reaches `case_level_latest_doc_answers`**
+- **Given** a `CheckStatusOfAnswerGenerationTask` job whose job data carries `queryLevel=CASE`,
+  a `caseId`, `queryId`, `docId`, and a resolved `ragTransactionId`
+- **When** the RAG status poll returns `ANSWER_GENERATED`
+- **Then** `caseLevelLatestDocumentAnswerService.upsert(...)` is called with that exact
+  transaction id, and the persisted row's `rag_transaction_id` column equals it.
+- **Proof (unit):** `CheckStatusOfAnswerGenerationTaskTest.shouldPassRagTransactionId_toCaseLevelLatestDocAnswerService_forCaseLevelQuery`
+  + `CaseLevelLatestDocumentAnswerServiceTest.shouldPassCorrectParametersToUpsertQuery` (asserts
+  `rag_transaction_id` in the captured `MapSqlParameterSource`).
+- **Proof (integration):** `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.checkStatusTask_persistsRagTransactionId_forCaseLevelAnswer`
+  — seeds a real Task Manager `jobs` row, lets the live app's `JobExecutor` (polling every 5s)
+  pick it up and run the real task against the real DB and the RAG WireMock stub
+  (`/answer-user-query-async-status/.*` → `ANSWER_GENERATED`), then asserts
+  `case_level_latest_doc_answers.rag_transaction_id` via JDBC. **Automated and green** against the
+  full compose stack.
+
+**Scenario 2.2 — `CASE_ALL_DOCUMENTS` level: transaction id reaches `case_level_all_documents_answers`**
+- **Given/When** as above with `queryLevel=CASE_ALL_DOCUMENTS`
+- **Then** `caseLevelAllDocumentsAnswerService.upsert(...)` receives the transaction id and it
+  lands in `case_level_all_documents_answers.rag_transaction_id`.
+- **Proof (unit):** `CheckStatusOfAnswerGenerationTaskTest.shouldPassRagTransactionId_toCaseLevelAllDocumentsAnswerService_forCaseAllDocumentsLevelQuery`
+  + `CaseLevelAllDocumentsAnswerServiceTest.shouldPassCorrectParametersToUpsertQuery`.
+- **Proof (integration):** **not yet automated.** No live-stack test currently drives this
+  specific level. The mechanism is identical to Scenario 2.1's proven path (same task, same
+  `JobExecutor` seam, only `queryLevel` and the target table differ), so risk is judged low, but
+  this is a real, disclosed gap — extend
+  `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` with a third case if this needs closing.
+
+**Scenario 2.3 — `DEFENDANT` level: transaction id reaches `defendant_answers`**
+- **Given/When** as above with `queryLevel=DEFENDANT` and a `defendantId`
+- **Then** `defendantAnswerService.upsert(...)` receives the transaction id and it lands in
+  `defendant_answers.rag_transaction_id`.
+- **Proof (unit):** `CheckStatusOfAnswerGenerationTaskTest.shouldPassRagTransactionId_toDefendantAnswerService_forDefendantLevelQuery`
+  + `DefendantAnswerServiceTest.shouldUseCorrectParametersForUpsert`.
+- **Proof (integration):** **not yet automated** — same disclosed gap as 2.2.
+
+**Scenario 2.4 — Default/`null` level: transaction id reaches `answers`**
+- **Given/When** as above with no `queryLevel` set (or an unrecognised value, which
+  `TaskUtils.parseQueryLevel` maps to `null`)
+- **Then** `answerGenerationService.upsertAnswer(...)` receives the transaction id and it lands
+  in `answers.rag_transaction_id`.
+- **Proof (unit):** `CheckStatusOfAnswerGenerationTaskTest.shouldSaveAnswerToCdkDatabase_andCompleteJob_whenAnswerGenerationSuccessful`
+  + `AnswerGenerationServiceTest.shouldPassCorrectParamsToUpsert`.
+- **Proof (integration):** `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.checkStatusTask_persistsRagTransactionId_forDefaultLevelAnswer`
+  — **automated and green** against the full compose stack.
+
+**Scenario 2.5 — Re-upsert overwrites a stale transaction id, never leaves it behind**
+- **Given** an existing answer row at `(case_id, query_id[, defendant_id], version)` with a prior
+  `rag_transaction_id`
+- **When** the same version is upserted again with a new transaction id (e.g. an
+  `ANSWER_GENERATION_FAILED` retry that eventually succeeds and reuses the same version number)
+- **Then** the row's `rag_transaction_id` is updated to the new value via
+  `ON CONFLICT ... DO UPDATE SET rag_transaction_id = EXCLUDED.rag_transaction_id`, not left stale.
+- **Proof (unit):** each of the four service tests exercises the single `UPSERT_SQL` statement
+  containing that `ON CONFLICT` clause and asserts the parameter is bound — the SQL text itself
+  (not just the Java call) guarantees the overwrite semantics, since Postgres executes exactly
+  that one statement for both the insert and the update path.
+- **Proof (integration):** **not yet automated** — would require seeding two sequential jobs
+  against the same `(case_id, query_id, version)` and asserting the second transaction id wins.
+  Judged lower priority: the guarantee is structural (one SQL statement, not two divergent code
+  paths), so unit coverage of the SQL text is considered sufficient for now.
+
+**Scenario 2.6 — No API/contract regression**
+- **Given** the existing Answers read API
+- **When** `GET /cases/{caseId}/queries/{queryId}/answers/with-llm`, `.../answers/list`, and the
+  `/v2/...` answers endpoints are called
+- **Then** the response body is byte-for-byte unchanged — no `ragTransactionId` field appears,
+  confirming `AnswerMapper`/`AnswerResponse`/`AnswerWithLlmResponse`/`version.cdk` were untouched
+  (ADR-002).
+- **Proof (integration):** `AnswersHttpLiveTest` (pre-existing, unmodified) — all its assertions
+  on exact response-body content continue to pass unchanged after this PR, which is the actual
+  regression signal (a new field would have broken nothing there since the assertions use
+  `contains(...)`, so this is a weak negative check; strengthened by `AC-008`'s point that
+  `AnswerMapper`'s source diff is empty — verifiable directly from the PR diff, not just runtime
+  behaviour).
+
+---
+
+## Story 3 — Keep the read-side JPA entities in sync with the new column
+
+**Scenario 3.1 — `Answer` entity constructor includes the new field**
+- **Given** the flat `Answer` JPA entity (does not extend `BaseAnswer`)
+- **When** constructed via its Lombok `@AllArgsConstructor`
+- **Then** the constructor has 6 parameters (`answerId`, `createdAt`, `answerText`, `llmInput`,
+  `docId`, `ragTransactionId`), and existing callers were updated to match.
+- **Proof:** `AnswerMapperTest.testToAnswerResponse` / `testToAnswerWithLlm` — both call sites
+  updated to pass a 6th `UUID` argument; compilation itself is the primary proof (Lombok generates
+  the constructor from the field list, so a mismatch is a compile error, not a runtime one).
+
+**Scenario 3.2 — `BaseAnswer` subclasses inherit the field without altering their own constructors**
+- **Given** `CaseLevelAllDocumentsAnswer` (extends `BaseAnswer` directly) and
+  `CaseLevelLatestDocumentAnswer`/`DefendantAnswer` (extend `DocumentAnswer` → `BaseAnswer`)
+- **When** `ragTransactionId` is added to `BaseAnswer`
+- **Then** none of the three subclasses' own `@AllArgsConstructor`s change shape, because Lombok's
+  `@AllArgsConstructor` only includes fields declared directly on the annotated class, not
+  inherited ones — each subclass's constructor still takes only its own `@EmbeddedId` field.
+- **Proof:** `./gradlew compileJava` succeeds with no changes required in any of the three
+  subclasses or their existing tests/usages — a genuinely different generated-constructor shape
+  would have surfaced as a compile error at every existing call site.
+
+**Scenario 3.3 — No mapper/DTO/contract change**
+- **Given** `AnswerMapper.toAnswerResponse` / `toAnswerWithLlm`
+- **When** mapping an `Answer` entity that now carries a non-null `ragTransactionId`
+- **Then** the produced `AnswerResponse`/`AnswerWithLlmResponse` still has no `ragTransactionId`
+  field — the mapper's `unmappedTargetPolicy = ReportingPolicy.IGNORE` combined with hand-written
+  `default` methods means an unmapped source field is silently dropped by design, not surfaced.
+- **Proof:** `AnswerMapperTest` assertions enumerate every field on the response objects
+  explicitly and never reference `ragTransactionId`; the mapper source diff for this PR is empty.
+
+---
+
+## Coverage summary
+
+| AC | Scenario | Unit | Integration |
+|----|----------|------|--------------|
+| AC-001 (CASE) | 2.1 | ✅ | ✅ |
+| AC-002 (CASE_ALL_DOCUMENTS) | 2.2 | ✅ | ⬜ disclosed gap |
+| AC-003 (DEFENDANT) | 2.3 | ✅ | ⬜ disclosed gap |
+| AC-004 (default) | 2.4 | ✅ | ✅ |
+| AC-005 (upsert overwrite) | 2.5 | ✅ | ⬜ disclosed gap |
+| AC-006 (no backfill) | 1.2 | ✅ (implicit) | — |
+| AC-007/AC-008 (no API change) | 2.6 / 3.3 | ✅ | ✅ (pre-existing suite unmodified) |
+| AC-009 (migration shape) | 1.1 | ✅ (implicit via Testcontainers) | ✅ (app boots against it every IT run) |
+| AC-010–AC-013 (test/quality gates) | — | ✅ (`gradle test`, PMD, JaCoCo all green) | ✅ (`gradle integration` full suite green) |
+
+No scenario is silently uncovered — the three ⬜ rows are the same structural gap (CASE_ALL_DOCUMENTS
+and DEFENDANT levels, and the overwrite case, aren't yet driven through the live compose stack),
+carried forward as a known follow-up rather than hidden.

--- a/docs/pipeline/adrs/DD-43084-persist-rag-transaction-id.md
+++ b/docs/pipeline/adrs/DD-43084-persist-rag-transaction-id.md
@@ -1,0 +1,105 @@
+# Architecture Decision Records — Persist RAG `transactionId` on Answer Records
+
+> Service: `cp-case-document-knowledge-service` (CDKS) · Jira: DD-43084 · Taken at the Stage 1 → Stage 2 human gate.
+> Requirement: [`../DD-43084-persist-rag-transaction-id/`](../DD-43084-persist-rag-transaction-id/) ·
+> Requirements: [`01-requirements.md`](../DD-43084-persist-rag-transaction-id/01-requirements.md) ·
+> Design: [`02-design.md`](../DD-43084-persist-rag-transaction-id/02-design.md)
+
+---
+
+## ADR-001: Add a nullable `rag_transaction_id` column to each of the four answer tables, not a new join table or a column on `case_query_status`
+
+- **Status:** Accepted · **Date:** 2026-08-07 · **Jira:** DD-43084
+- **Artefacts:** `01-requirements.md` (FR-001–FR-005, FR-008) · `02-design.md` (§1–§3)
+
+### Context
+
+`GenerateAnswerForQueryTask` receives a `transactionId` from the RAG service's async accept
+response and forwards it via Task Manager job data (`ragTransactionId`) to
+`CheckStatusOfAnswerGenerationTask`. That task already resolves it to a `UUID` local variable to
+poll `answerUserQueryStatus(...)`, but drops it before calling any of the four persistence paths —
+`AnswerGenerationService.upsertAnswer`, `CaseLevelLatestDocumentAnswerService.upsert`,
+`CaseLevelAllDocumentsAnswerService.upsert`, `DefendantAnswerService.upsert` — none of which accept
+it, and none of the four backing tables (`answers`, `case_level_latest_doc_answers`,
+`case_level_all_documents_answers`, `defendant_answers`) have a column for it. This is the same
+category of problem the CDKS hard rule "do not drop RAG response fields" already names for
+`doc_id`/`llm_input` (`.claude/context/cdks-context.md`).
+
+Each of the four tables is a versioned, append-on-upsert record per `(case_id, query_id[,
+defendant_id], version)` — every version is a distinct RAG-generation outcome and therefore a
+distinct `transactionId`. `case_query_status`, by contrast, is a single current-state pointer per
+`(case_id, query_id)` — it already only tracks `last_answer_version`/`last_answer_at`, not history.
+
+### Decision
+
+Add `rag_transaction_id UUID NULL` to all four answer tables via one additive Flyway migration
+(`V1012`), and thread the already-resolved `transactionId` from `CheckStatusOfAnswerGenerationTask`
+into all four upsert calls, written on both `INSERT` and `ON CONFLICT ... DO UPDATE SET`.
+
+### Alternatives considered
+
+- **New `answer_rag_transactions` table** (case_id, query_id, version, transaction_id) —
+  rejected: over-engineered for a 1:1 scalar; `llm_input` already sets the precedent of storing
+  per-version RAG-derived metadata as a plain column on each answer table, not a side table.
+- **Store only on `case_query_status`** — rejected: it is a latest-pointer, not a version history;
+  storing there would lose the transaction id for every superseded version, defeating the
+  traceability goal the ticket is about.
+- **`NOT NULL` column** — rejected: would require a backfill value for any pre-existing rows that
+  don't have one (none recoverable from RAG after the fact), and adds rigidity to a
+  traceability/diagnostic field that is not a business key.
+
+### Consequences
+
+- **Positive:** every future successful answer generation is traceable back to the exact RAG
+  transaction that produced it, per version, matching the granularity of the data it's attached
+  to. `ADD COLUMN ... NULL` on Postgres is a metadata-only change (no table rewrite), so rollout
+  risk on existing tables is low regardless of current row counts.
+- **Accepted:** rows written before this change (and any `ANSWER_GENERATION_FAILED` attempt, which
+  was never persisted before or after this change) show `rag_transaction_id IS NULL` — no
+  backfill is attempted or possible.
+- **Reversible:** the column can be dropped again in a future migration without touching
+  application logic beyond reverting the parameter threading; adding it does not touch
+  `case_query_status`, the trigger `trg_answers_after_insert`, or any other table.
+
+---
+
+## ADR-002: `rag_transaction_id` is persisted only — no API/contract change this iteration
+
+- **Status:** Accepted · **Date:** 2026-08-07 · **Jira:** DD-43084
+- **Artefacts:** `01-requirements.md` (FR-006, FR-007) · `02-design.md` (§4)
+
+### Context
+
+The brief asks specifically for the value to be *stored*, not surfaced. CDKS's Answers API
+(`AnswersController` → `AnswerMapper` → `AnswerResponse`/`AnswerWithLlmResponse`/`AnswersResponse`,
+generated from `api-cp-crime-caseadmin-case-document-knowledge`) has no stated consumer need for a
+RAG-internal transaction id today, and exposing an upstream vendor system's correlation id over a
+public contract is a distinct product decision from persisting it for internal traceability.
+
+### Decision
+
+Persist `rag_transaction_id` in the database and (read-side) JPA entities only. Do not add it to
+`AnswerResponse`, `AnswerWithLlmResponse`, or `AnswersResponse`; do not touch `AnswerMapper`; do
+not bump `version.cdk` or touch `api-cp-crime-caseadmin-case-document-knowledge`. Support/ops
+traceability needs are met by querying the database directly (the stated driver behind this
+ticket), not by a new API surface.
+
+### Alternatives considered
+
+- **Add `ragTransactionId` to `AnswerWithLlmResponse`** — rejected as out of scope: no named
+  consumer, would require a contract-first change in the external API-spec repo (mirroring
+  DD-43036's approach), and risks leaking upstream implementation detail to API consumers without
+  a stated need.
+- **New `GET .../answers/by-transaction/{transactionId}` lookup endpoint** — rejected as out of
+  scope: not asked for; would need its own requirements/ACL pass.
+
+### Consequences
+
+- **Positive:** zero contract risk, zero `version.cdk` dependency, ships entirely within this
+  repo; smaller, easier-to-review diff.
+- **Reversible — additive later:** exposing the field via the API afterward is a strictly additive
+  contract change (new optional response field) once the column already exists — no migration
+  needed at that point, only a mapper change and a contract bump.
+- **Open question carried to Requirements (OQ-001):** if the actual Jira ticket text (not directly
+  fetched in this session — see `00-input-brief.md`) turns out to ask for API exposure too, this
+  ADR's scope boundary needs revisiting before Story stage.

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.java
@@ -1,0 +1,146 @@
+package uk.gov.hmcts.cp.cdk.jobmanager.queryflow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.CHECK_STATUS_OF_ANSWER_GENERATION;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_KEY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_QUERY_LEVEL;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_RAG_TRANSACTION_ID;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_SINGLE_QUERY_ID;
+
+import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that CheckStatusOfAnswerGenerationTask persists the RAG transactionId it already
+ * resolves for status-polling into the answer row it writes (DD-43084).
+ *
+ * <p>GENERATE_ANSWER_FOR_QUERY / CHECK_STATUS_OF_ANSWER_GENERATION are only ever dispatched
+ * internally, deep in the ingestion pipeline — there is no HTTP entry point that reaches them
+ * directly. Task Manager's jobs table (task-manager-service, polled every
+ * {@code job.executor.poll-interval}, default 5s) is the seam this test drives instead: seed a
+ * job row addressed to CHECK_STATUS_OF_ANSWER_GENERATION with the same job-data shape
+ * GenerateAnswerForQueryTask would have produced, let the live app's scheduled JobExecutor pick
+ * it up and run the real task against the real DB and the existing RAG WireMock stub
+ * ({@code /answer-user-query-async-status/.*} → ANSWER_GENERATED), then assert the persisted
+ * column via JDBC.
+ */
+class CheckStatusOfAnswerGenerationRagTransactionIdLiveTest extends AbstractHttpLiveTest {
+
+    private static final String INSERT_JOB_SQL =
+            "INSERT INTO jobs (job_id, assigned_task_name, assigned_task_start_time, job_data, "
+                    + "priority, retry_attempts_remaining, worker_id, worker_lock_time) "
+                    + "VALUES (?, ?, NOW(), ?, 10, 3, NULL, NULL)";
+
+    @Test
+    @DisplayName("Default-level answer persists the RAG transactionId into answers.rag_transaction_id")
+    void checkStatusTask_persistsRagTransactionId_forDefaultLevelAnswer() throws Exception {
+        final UUID caseId = UUID.randomUUID();
+        final UUID queryId = UUID.randomUUID();
+        final UUID transactionId = UUID.randomUUID();
+
+        seedQuery(queryId);
+        seedCheckStatusJob(caseId, queryId, transactionId, null);
+
+        try {
+            awaitRagTransactionId("answers", caseId, queryId, transactionId);
+        } finally {
+            cleanup("answers", caseId, queryId);
+        }
+    }
+
+    @Test
+    @DisplayName("CASE-level answer persists the RAG transactionId into case_level_latest_doc_answers.rag_transaction_id")
+    void checkStatusTask_persistsRagTransactionId_forCaseLevelAnswer() throws Exception {
+        final UUID caseId = UUID.randomUUID();
+        final UUID queryId = UUID.randomUUID();
+        final UUID transactionId = UUID.randomUUID();
+
+        seedQuery(queryId);
+        seedCheckStatusJob(caseId, queryId, transactionId, "CASE");
+
+        try {
+            awaitRagTransactionId("case_level_latest_doc_answers", caseId, queryId, transactionId);
+        } finally {
+            cleanup("case_level_latest_doc_answers", caseId, queryId);
+        }
+    }
+
+    private void seedQuery(final UUID queryId) throws Exception {
+        try (Connection c = openConnection();
+             PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO queries (query_id, label, created_at) VALUES (?, 'RAG transactionId live test query', NOW())")) {
+            ps.setObject(1, queryId);
+            ps.executeUpdate();
+        }
+    }
+
+    private void seedCheckStatusJob(final UUID caseId, final UUID queryId, final UUID transactionId,
+                                    final String queryLevelOrNull) throws Exception {
+        final StringBuilder jobData = new StringBuilder("{")
+                .append("\"").append(CTX_CASE_ID_KEY).append("\":\"").append(caseId).append("\",")
+                .append("\"").append(CTX_SINGLE_QUERY_ID).append("\":\"").append(queryId).append("\",")
+                .append("\"").append(CTX_RAG_TRANSACTION_ID).append("\":\"").append(transactionId).append("\"");
+        if (queryLevelOrNull != null) {
+            jobData.append(",\"").append(CTX_QUERY_LEVEL).append("\":\"").append(queryLevelOrNull).append("\"");
+        }
+        jobData.append("}");
+
+        try (Connection c = openConnection();
+             PreparedStatement ps = c.prepareStatement(INSERT_JOB_SQL)) {
+            ps.setObject(1, UUID.randomUUID());
+            ps.setString(2, CHECK_STATUS_OF_ANSWER_GENERATION);
+            ps.setString(3, jobData.toString());
+            ps.executeUpdate();
+        }
+    }
+
+    private void awaitRagTransactionId(final String table, final UUID caseId, final UUID queryId,
+                                       final UUID expectedTransactionId) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(60))
+                .pollInterval(Duration.ofSeconds(2))
+                .untilAsserted(() -> {
+                    try (Connection c = openConnection();
+                         PreparedStatement ps = c.prepareStatement(
+                                 "SELECT rag_transaction_id FROM " + table + " WHERE case_id = ? AND query_id = ?")) {
+                        ps.setObject(1, caseId);
+                        ps.setObject(2, queryId);
+                        try (ResultSet rs = ps.executeQuery()) {
+                            assertThat(rs.next()).as("answer row must exist in %s", table).isTrue();
+                            assertThat(rs.getObject("rag_transaction_id", UUID.class))
+                                    .isEqualTo(expectedTransactionId);
+                        }
+                    }
+                });
+    }
+
+    private void cleanup(final String table, final UUID caseId, final UUID queryId) throws Exception {
+        try (Connection c = openConnection()) {
+            try (PreparedStatement ps = c.prepareStatement(
+                    "DELETE FROM case_query_status WHERE case_id = ? AND query_id = ?")) {
+                ps.setObject(1, caseId);
+                ps.setObject(2, queryId);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = c.prepareStatement(
+                    "DELETE FROM " + table + " WHERE case_id = ? AND query_id = ?")) {
+                ps.setObject(1, caseId);
+                ps.setObject(2, queryId);
+                ps.executeUpdate();
+            }
+            try (PreparedStatement ps = c.prepareStatement("DELETE FROM queries WHERE query_id = ?")) {
+                ps.setObject(1, queryId);
+                ps.executeUpdate();
+            }
+        }
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest.java
@@ -12,8 +12,10 @@ import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
@@ -51,7 +53,8 @@ class CheckStatusOfAnswerGenerationRagTransactionIdLiveTest extends AbstractHttp
         seedCheckStatusJob(caseId, queryId, transactionId, null);
 
         try {
-            awaitRagTransactionId("answers", caseId, queryId, transactionId);
+            final UUID persisted = awaitRagTransactionId("answers", caseId, queryId);
+            assertThat(persisted).isEqualTo(transactionId);
         } finally {
             cleanup("answers", caseId, queryId);
         }
@@ -68,13 +71,14 @@ class CheckStatusOfAnswerGenerationRagTransactionIdLiveTest extends AbstractHttp
         seedCheckStatusJob(caseId, queryId, transactionId, "CASE");
 
         try {
-            awaitRagTransactionId("case_level_latest_doc_answers", caseId, queryId, transactionId);
+            final UUID persisted = awaitRagTransactionId("case_level_latest_doc_answers", caseId, queryId);
+            assertThat(persisted).isEqualTo(transactionId);
         } finally {
             cleanup("case_level_latest_doc_answers", caseId, queryId);
         }
     }
 
-    private void seedQuery(final UUID queryId) throws Exception {
+    private void seedQuery(final UUID queryId) throws SQLException {
         try (Connection c = openConnection();
              PreparedStatement ps = c.prepareStatement(
                      "INSERT INTO queries (query_id, label, created_at) VALUES (?, 'RAG transactionId live test query', NOW())")) {
@@ -84,46 +88,50 @@ class CheckStatusOfAnswerGenerationRagTransactionIdLiveTest extends AbstractHttp
     }
 
     private void seedCheckStatusJob(final UUID caseId, final UUID queryId, final UUID transactionId,
-                                    final String queryLevelOrNull) throws Exception {
-        final StringBuilder jobData = new StringBuilder("{")
-                .append("\"").append(CTX_CASE_ID_KEY).append("\":\"").append(caseId).append("\",")
-                .append("\"").append(CTX_SINGLE_QUERY_ID).append("\":\"").append(queryId).append("\",")
-                .append("\"").append(CTX_RAG_TRANSACTION_ID).append("\":\"").append(transactionId).append("\"");
-        if (queryLevelOrNull != null) {
-            jobData.append(",\"").append(CTX_QUERY_LEVEL).append("\":\"").append(queryLevelOrNull).append("\"");
-        }
-        jobData.append("}");
+                                    final String queryLevelOrNull) throws SQLException {
+        final String levelField = queryLevelOrNull == null
+                ? ""
+                : ",\"%s\":\"%s\"".formatted(CTX_QUERY_LEVEL, queryLevelOrNull);
+        final String jobData = "{\"%s\":\"%s\",\"%s\":\"%s\",\"%s\":\"%s\"%s}".formatted(
+                CTX_CASE_ID_KEY, caseId, CTX_SINGLE_QUERY_ID, queryId, CTX_RAG_TRANSACTION_ID, transactionId, levelField);
 
         try (Connection c = openConnection();
              PreparedStatement ps = c.prepareStatement(INSERT_JOB_SQL)) {
             ps.setObject(1, UUID.randomUUID());
             ps.setString(2, CHECK_STATUS_OF_ANSWER_GENERATION);
-            ps.setString(3, jobData.toString());
+            ps.setString(3, jobData);
             ps.executeUpdate();
         }
     }
 
-    private void awaitRagTransactionId(final String table, final UUID caseId, final UUID queryId,
-                                       final UUID expectedTransactionId) {
+    private UUID awaitRagTransactionId(final String table, final UUID caseId, final UUID queryId) {
+        final AtomicReference<UUID> found = new AtomicReference<>();
         Awaitility.await()
                 .atMost(Duration.ofSeconds(60))
                 .pollInterval(Duration.ofSeconds(2))
-                .untilAsserted(() -> {
-                    try (Connection c = openConnection();
-                         PreparedStatement ps = c.prepareStatement(
-                                 "SELECT rag_transaction_id FROM " + table + " WHERE case_id = ? AND query_id = ?")) {
-                        ps.setObject(1, caseId);
-                        ps.setObject(2, queryId);
-                        try (ResultSet rs = ps.executeQuery()) {
-                            assertThat(rs.next()).as("answer row must exist in %s", table).isTrue();
-                            assertThat(rs.getObject("rag_transaction_id", UUID.class))
-                                    .isEqualTo(expectedTransactionId);
-                        }
-                    }
+                .until(() -> {
+                    found.set(fetchRagTransactionId(table, caseId, queryId));
+                    return found.get() != null;
                 });
+        return found.get();
     }
 
-    private void cleanup(final String table, final UUID caseId, final UUID queryId) throws Exception {
+    private UUID fetchRagTransactionId(final String table, final UUID caseId, final UUID queryId) throws SQLException {
+        try (Connection c = openConnection();
+             PreparedStatement ps = c.prepareStatement(
+                     "SELECT rag_transaction_id FROM " + table + " WHERE case_id = ? AND query_id = ?")) {
+            ps.setObject(1, caseId);
+            ps.setObject(2, queryId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getObject("rag_transaction_id", UUID.class);
+                }
+                return null;
+            }
+        }
+    }
+
+    private void cleanup(final String table, final UUID caseId, final UUID queryId) throws SQLException {
         try (Connection c = openConnection()) {
             try (PreparedStatement ps = c.prepareStatement(
                     "DELETE FROM case_query_status WHERE case_id = ? AND query_id = ?")) {

--- a/src/integrationTest/resources/wiremock/__files/hearing_cases_for_day_api_response.json
+++ b/src/integrationTest/resources/wiremock/__files/hearing_cases_for_day_api_response.json
@@ -1,0 +1,3 @@
+{
+  "hearingCases": []
+}

--- a/src/integrationTest/resources/wiremock/mappings/hearing_cases_for_day_api.json
+++ b/src/integrationTest/resources/wiremock/mappings/hearing_cases_for_day_api.json
@@ -1,0 +1,17 @@
+{
+  "priority": 10,
+  "request": {
+    "method": "GET",
+    "urlPath": "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day",
+    "queryParameters": {
+      "date": { "matches": ".*" }
+    }
+  },
+  "response": {
+    "status": 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName": "hearing_cases_for_day_api_response.json"
+  }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/domain/Answer.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/domain/Answer.java
@@ -52,4 +52,7 @@ public class Answer {
 
     @Column(name = "doc_id")
     private UUID docId;
+
+    @Column(name = "rag_transaction_id")
+    private UUID ragTransactionId;
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/domain/BaseAnswer.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/domain/BaseAnswer.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cp.cdk.domain;
 import static uk.gov.hmcts.cp.cdk.util.TimeUtils.utcNow;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
@@ -21,4 +22,7 @@ public class BaseAnswer {
 
     @Column(name = "llm_input", columnDefinition = "TEXT")
     protected String llmInput;
+
+    @Column(name = "rag_transaction_id")
+    protected UUID ragTransactionId;
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTask.java
@@ -103,7 +103,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     queryId,
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
-                                    documentId
+                                    documentId,
+                                    transactionId
                             );
                             break;
 
@@ -112,7 +113,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     caseId,
                                     queryId,
                                     answerResponseBody.getLlmResponse(),
-                                    llmInputJson
+                                    llmInputJson,
+                                    transactionId
                             );
                             break;
 
@@ -123,7 +125,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     defendantId,
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
-                                    documentId
+                                    documentId,
+                                    transactionId
                             );
                             break;
                         case null, default:
@@ -132,7 +135,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     queryId,
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
-                                    documentId
+                                    documentId,
+                                    transactionId
                             );
                             break;
                     }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTask.java
@@ -71,17 +71,17 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
     public ExecutionInfo execute(final ExecutionInfo executionInfo) {
 
         final JsonObject jobData = executionInfo.getJobData();
-        final UUID transactionId = parseUuidOrNull(jobData.getString(CTX_RAG_TRANSACTION_ID, null));
+        final UUID ragTransactionId = parseUuidOrNull(jobData.getString(CTX_RAG_TRANSACTION_ID, null));
 
         try {
-            final ResponseEntity<@NotNull UserQueryAnswerReturnedSuccessfullyAsynchronously> userQueryAnswerResponse = documentInformationSummarisedAsynchronouslyApi.answerUserQueryStatus(transactionId.toString(), true);
+            final ResponseEntity<@NotNull UserQueryAnswerReturnedSuccessfullyAsynchronously> userQueryAnswerResponse = documentInformationSummarisedAsynchronouslyApi.answerUserQueryStatus(ragTransactionId.toString(), true);
 
             if (isNull(userQueryAnswerResponse)
                     || !userQueryAnswerResponse.getStatusCode().is2xxSuccessful()
                     || isNull(userQueryAnswerResponse.getBody())
                     || ANSWER_GENERATION_PENDING == userQueryAnswerResponse.getBody().getStatus()) {
 
-                log.info("Answer Generation in progress for the transactionId={} → retrying", transactionId);
+                log.info("Answer Generation in progress for the ragTransactionId={} → retrying", ragTransactionId);
                 return retry(executionInfo);
             }
 
@@ -104,7 +104,7 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
                                     documentId,
-                                    transactionId
+                                    ragTransactionId
                             );
                             break;
 
@@ -114,7 +114,7 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     queryId,
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
-                                    transactionId
+                                    ragTransactionId
                             );
                             break;
 
@@ -126,7 +126,7 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
                                     documentId,
-                                    transactionId
+                                    ragTransactionId
                             );
                             break;
                         case null, default:
@@ -136,19 +136,19 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                                     answerResponseBody.getLlmResponse(),
                                     llmInputJson,
                                     documentId,
-                                    transactionId
+                                    ragTransactionId
                             );
                             break;
                     }
 
 
-                log.info("Answer Generation updated in the DB for caseId={}, docId={}, queryId={}, transactionId={}, task completed.",
-                        caseId, documentId, queryId, transactionId);
+                log.info("Answer Generation updated in the DB for caseId={}, docId={}, queryId={}, ragTransactionId={}, task completed.",
+                        caseId, documentId, queryId, ragTransactionId);
             }
 
             if (ANSWER_GENERATION_FAILED == answerResponseBody.getStatus()) {
-                log.info("Answer Generation Failed for caseId={}, docId={}, queryId={}, transactionId={}, task completed.",
-                        caseId, documentId, queryId, transactionId);
+                log.info("Answer Generation Failed for caseId={}, docId={}, queryId={}, ragTransactionId={}, task completed.",
+                        caseId, documentId, queryId, ragTransactionId);
 
                 final int retryCount = jobData.containsKey(CTX_ANSWER_RETRY_COUNT)
                         ? jobData.getInt(CTX_ANSWER_RETRY_COUNT)
@@ -158,8 +158,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
 
                 if (retryCount < maxRetries) {
 
-                    log.info("Answer generation failed. Retrying {}/{} for transactionId={}",
-                            retryCount + 1, maxRetries, transactionId);
+                    log.info("Answer generation failed. Retrying {}/{} for ragTransactionId={}",
+                            retryCount + 1, maxRetries, ragTransactionId);
 
                     final JsonObject singleCaseJobData = createObjectBuilder(jobData)
                             .add(CTX_ANSWER_RETRY_COUNT, retryCount + 1)
@@ -175,8 +175,8 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                     executionService.executeWith(executionInfoNew);
 
                 } else {
-                    log.warn("Max retries reached for caseId={}, queryId={}, transactionId={}",
-                            caseId, queryId, transactionId);
+                    log.warn("Max retries reached for caseId={}, queryId={}, ragTransactionId={}",
+                            caseId, queryId, ragTransactionId);
                 }
             }
 
@@ -186,7 +186,7 @@ public class CheckStatusOfAnswerGenerationTask implements ExecutableTask {
                     .build();
 
         } catch (final Exception ex) {
-            log.error("Failed to check answer generation status RAG for transactionId={}", transactionId, ex);
+            log.error("Failed to check answer generation status RAG for ragTransactionId={}", ragTransactionId, ex);
             return retry(executionInfo);
         }
     }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/AnswerGenerationService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/AnswerGenerationService.java
@@ -27,12 +27,13 @@ public class AnswerGenerationService {
 
     /* default */
     static final String SQL_UPSERT_ANSWER =
-            "INSERT INTO answers(case_id, query_id, version, created_at, answer, llm_input, doc_id) " +
-                    "VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :doc_id) " +
+            "INSERT INTO answers(case_id, query_id, version, created_at, answer, llm_input, doc_id, rag_transaction_id) " +
+                    "VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :doc_id, :rag_transaction_id) " +
                     "ON CONFLICT (case_id, query_id, version) DO UPDATE SET " +
                     "  answer = EXCLUDED.answer, " +
                     "  llm_input = EXCLUDED.llm_input, " +
                     "  doc_id = EXCLUDED.doc_id, " +
+                    "  rag_transaction_id = EXCLUDED.rag_transaction_id, " +
                     "  created_at = EXCLUDED.created_at";
 
     /* default */
@@ -50,14 +51,14 @@ public class AnswerGenerationService {
 
     @Transactional
     public void upsertAnswer(final UUID caseId, final UUID queryId, final String answer,
-                             final String llmInput, final UUID docId) {
+                             final String llmInput, final UUID docId, final UUID ragTransactionId) {
 
         // 1. get version
         final Integer version = getVersionNumber(caseId, queryId);
         log.info("Next version={} found for the caseId={}, queryId={}", version, caseId, queryId);
 
         // 2. upsert answer
-        final MapSqlParameterSource params = buildAnswerParams(caseId, queryId, version, answer, llmInput, docId);
+        final MapSqlParameterSource params = buildAnswerParams(caseId, queryId, version, answer, llmInput, docId, ragTransactionId);
         namedParameterJdbcTemplate.update(SQL_UPSERT_ANSWER, params);
 
         // 3. update case_query_status (replaces trigger)

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/CaseLevelAllDocumentsAnswerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/CaseLevelAllDocumentsAnswerService.java
@@ -28,16 +28,18 @@ public class CaseLevelAllDocumentsAnswerService {
 
     private static final String UPSERT_SQL = """
         INSERT INTO case_level_all_documents_answers
-        (case_id, query_id, version, created_at, answer, llm_input)
-        VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input)
+        (case_id, query_id, version, created_at, answer, llm_input, rag_transaction_id)
+        VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :rag_transaction_id)
         ON CONFLICT (case_id, query_id, version) DO UPDATE SET
             answer = EXCLUDED.answer,
             llm_input = EXCLUDED.llm_input,
+            rag_transaction_id = EXCLUDED.rag_transaction_id,
             created_at = EXCLUDED.created_at
     """;
 
     @Transactional
-    public void upsert(final UUID caseId, final UUID queryId, final String answer, final String llmInput) {
+    public void upsert(final UUID caseId, final UUID queryId, final String answer, final String llmInput,
+                       final UUID ragTransactionId) {
 
         final int version = getVersionNumber(caseId, queryId);
 
@@ -46,7 +48,8 @@ public class CaseLevelAllDocumentsAnswerService {
                 .addValue("query_id", queryId)
                 .addValue("version", version)
                 .addValue("answer", answer)
-                .addValue("llm_input", llmInput);
+                .addValue("llm_input", llmInput)
+                .addValue("rag_transaction_id", ragTransactionId);
 
         jdbc.update(UPSERT_SQL, params);
 

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/CaseLevelLatestDocumentAnswerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/CaseLevelLatestDocumentAnswerService.java
@@ -28,18 +28,19 @@ public class CaseLevelLatestDocumentAnswerService {
 
     private static final String UPSERT_SQL = """
         INSERT INTO case_level_latest_doc_answers
-        (case_id, query_id, version, created_at, answer, llm_input, doc_id)
-        VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :doc_id)
+        (case_id, query_id, version, created_at, answer, llm_input, doc_id, rag_transaction_id)
+        VALUES (:case_id, :query_id, :version, NOW(), :answer, :llm_input, :doc_id, :rag_transaction_id)
         ON CONFLICT (case_id, query_id, version) DO UPDATE SET
             answer = EXCLUDED.answer,
             llm_input = EXCLUDED.llm_input,
             doc_id = EXCLUDED.doc_id,
+            rag_transaction_id = EXCLUDED.rag_transaction_id,
             created_at = EXCLUDED.created_at
     """;
 
     @Transactional
     public void upsert(final UUID caseId, final UUID queryId, final String answer,
-                       final String llmInput, final UUID docId) {
+                       final String llmInput, final UUID docId, final UUID ragTransactionId) {
 
         final int version = getVersionNumber(caseId, queryId);
 
@@ -49,7 +50,8 @@ public class CaseLevelLatestDocumentAnswerService {
                 .addValue("version", version)
                 .addValue("answer", answer)
                 .addValue("llm_input", llmInput)
-                .addValue("doc_id", docId);
+                .addValue("doc_id", docId)
+                .addValue("rag_transaction_id", ragTransactionId);
 
         jdbc.update(UPSERT_SQL, params);
 

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DefendantAnswerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DefendantAnswerService.java
@@ -29,19 +29,21 @@ public class DefendantAnswerService {
 
     private static final String UPSERT_SQL = """
         INSERT INTO defendant_answers
-        (case_id, query_id, defendant_id, version, created_at, answer, llm_input, doc_id)
-        VALUES (:case_id, :query_id, :defendant_id, :version, NOW(), :answer, :llm_input, :doc_id)
+        (case_id, query_id, defendant_id, version, created_at, answer, llm_input, doc_id, rag_transaction_id)
+        VALUES (:case_id, :query_id, :defendant_id, :version, NOW(), :answer, :llm_input, :doc_id, :rag_transaction_id)
         ON CONFLICT (case_id, query_id, defendant_id, version) DO UPDATE SET
             answer = EXCLUDED.answer,
             llm_input = EXCLUDED.llm_input,
             doc_id = EXCLUDED.doc_id,
+            rag_transaction_id = EXCLUDED.rag_transaction_id,
             created_at = EXCLUDED.created_at
     """;
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
     @Transactional
     public void upsert(final UUID caseId, final UUID queryId, final UUID defendantId,
-                       final String answer, final String llmInput, final UUID docId) {
+                       final String answer, final String llmInput, final UUID docId,
+                       final UUID ragTransactionId) {
 
         final Integer version = getVersionNumberWithDefendentId(caseId, queryId, defendantId);
 
@@ -52,7 +54,8 @@ public class DefendantAnswerService {
                 .addValue("version", version)
                 .addValue("answer", answer)
                 .addValue("llm_input", llmInput)
-                .addValue("doc_id", docId);
+                .addValue("doc_id", docId)
+                .addValue("rag_transaction_id", ragTransactionId);
 
         jdbc.update(UPSERT_SQL, params);
 

--- a/src/main/java/uk/gov/hmcts/cp/cdk/util/TaskUtils.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/util/TaskUtils.java
@@ -81,14 +81,16 @@ public class TaskUtils {
                                                           final Integer version,
                                                           final String answer,
                                                           final String llmInput,
-                                                          final UUID documentId) {
+                                                          final UUID documentId,
+                                                          final UUID ragTransactionId) {
         return new MapSqlParameterSource()
                 .addValue("case_id", caseId)
                 .addValue("query_id", queryId)
                 .addValue("version", version)
                 .addValue("answer", answer)
                 .addValue("llm_input", llmInput)
-                .addValue("doc_id", documentId);
+                .addValue("doc_id", documentId)
+                .addValue("rag_transaction_id", ragTransactionId);
     }
 
     public static MapSqlParameterSource buildCaseStatusParams(final UUID caseId,

--- a/src/main/resources/application-cdk.yml
+++ b/src/main/resources/application-cdk.yml
@@ -59,11 +59,11 @@ scheduler:
     cron: "0 0/10 7-19 * * MON-FRI"  # every 10 min, Mon–Fri, 07:00–19:50
     lock-at-least-for: "PT8M"
     lock-at-most-for: "PT9M"
-    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_INTRADAY_DISCOVERY_ENABLED:false}
   nightly-discovery:
     name: "nightlyDiscoveryScheduler"
     cron: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_CRON:0 0 2 * * *}"  # daily at 02:00
     lock-at-least-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_LEAST_FOR:PT1H}"
     lock-at-most-for: "${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_LOCK_AT_MOST_FOR:PT2H}"
-    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:true}
+    enabled: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_ENABLED:false}
     days-ahead: ${CP_CDK_SCHEDULER_NIGHTLY_DISCOVERY_DAYS_AHEAD:3}

--- a/src/main/resources/application-clients.yml
+++ b/src/main/resources/application-clients.yml
@@ -25,7 +25,7 @@ cqrs:
       get-hearings-path: "/hearing-query-api/query/api/rest/hearing/hearings"
       get-hearing-cases-for-day-accept-header: "application/vnd.hearing.get.hearing-cases-for-day+json"
       get-hearing-cases-for-day-path: "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day"
-      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:true}
+      is-hearing-for-cases-enabled: ${CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED:false}
     progression:
       accept-header: "application/vnd.progression.query.courtdocuments+json"
       doc-type-id: "41be14e8-9df5-4b08-80b0-1e670bc80a5b"

--- a/src/main/resources/db/migration/V1012__add_rag_transaction_id_to_answers.sql
+++ b/src/main/resources/db/migration/V1012__add_rag_transaction_id_to_answers.sql
@@ -1,0 +1,23 @@
+-- ----------------------------------------------------------------------------
+-- Persist the RAG service transactionId that produced each answer version.
+-- Nullable, additive: rows written before this migration keep NULL, no backfill.
+-- ----------------------------------------------------------------------------
+ALTER TABLE answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version (nullable — not backfilled for rows written before this column existed).';
+
+ALTER TABLE case_level_latest_doc_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN case_level_latest_doc_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';
+
+ALTER TABLE case_level_all_documents_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN case_level_all_documents_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';
+
+ALTER TABLE defendant_answers
+    ADD COLUMN IF NOT EXISTS rag_transaction_id UUID NULL;
+COMMENT ON COLUMN defendant_answers.rag_transaction_id IS
+'RAG service transactionId that produced this answer version.';

--- a/src/test/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/jobmanager/queryflow/CheckStatusOfAnswerGenerationTaskTest.java
@@ -5,13 +5,16 @@ import static java.time.ZonedDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.cp.cdk.jobmanager.TaskNames.CHECK_STATUS_OF_ANSWER_GENERATION;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_CASE_ID_KEY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_DEFENDANT_ID_KEY;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_DOC_ID_KEY;
+import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_QUERY_LEVEL;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_RAG_TRANSACTION_ID;
 import static uk.gov.hmcts.cp.cdk.jobmanager.support.JobManagerKeys.CTX_SINGLE_QUERY_ID;
 import static uk.gov.hmcts.cp.openapi.model.AnswerGenerationStatus.ANSWER_GENERATED;
@@ -20,6 +23,7 @@ import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.COMPLETED;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.INPROGRESS;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.STARTED;
 
+import uk.gov.hmcts.cp.cdk.domain.QueryLevel;
 import uk.gov.hmcts.cp.cdk.jobmanager.JobManagerRetryProperties;
 import uk.gov.hmcts.cp.cdk.services.AnswerGenerationService;
 import uk.gov.hmcts.cp.cdk.services.CaseLevelAllDocumentsAnswerService;
@@ -185,10 +189,63 @@ class CheckStatusOfAnswerGenerationTaskTest {
 
         final ExecutionInfo result = task.execute(executionInfo);
 
-        verify(answerGenerationService).upsertAnswer(any(UUID.class), any(UUID.class), anyString(), anyString(), any(UUID.class));
+        verify(answerGenerationService).upsertAnswer(any(UUID.class), any(UUID.class), anyString(), anyString(), any(UUID.class), eq(transactionId));
 
         assertThat(result.getExecutionStatus()).isEqualTo(COMPLETED);
         assertThat(result.isShouldRetry()).isFalse();
+    }
+
+    @Test
+    void shouldPassRagTransactionId_toCaseLevelLatestDocAnswerService_forCaseLevelQuery() {
+        final JsonObject jobData = createObjectBuilder(executionInfo.getJobData())
+                .add(CTX_QUERY_LEVEL, QueryLevel.CASE.name())
+                .build();
+        executionInfo = ExecutionInfo.executionInfo().from(executionInfo).withJobData(jobData).build();
+
+        when(body.getStatus()).thenReturn(ANSWER_GENERATED);
+        when(body.getLlmResponse()).thenReturn("llmResponse");
+        when(body.getDocumentChunks()).thenReturn(List.of());
+        when(api.answerUserQueryStatus(transactionId.toString(), true)).thenReturn(ResponseEntity.ok(body));
+
+        task.execute(executionInfo);
+
+        verify(caseLevelLatestDocumentAnswerService).upsert(eq(caseId), eq(queryId), anyString(), anyString(), eq(documentId), eq(transactionId));
+    }
+
+    @Test
+    void shouldPassRagTransactionId_toCaseLevelAllDocumentsAnswerService_forCaseAllDocumentsLevelQuery() {
+        final JsonObject jobData = createObjectBuilder(executionInfo.getJobData())
+                .add(CTX_QUERY_LEVEL, QueryLevel.CASE_ALL_DOCUMENTS.name())
+                .build();
+        executionInfo = ExecutionInfo.executionInfo().from(executionInfo).withJobData(jobData).build();
+
+        when(body.getStatus()).thenReturn(ANSWER_GENERATED);
+        when(body.getLlmResponse()).thenReturn("llmResponse");
+        when(body.getDocumentChunks()).thenReturn(List.of());
+        when(api.answerUserQueryStatus(transactionId.toString(), true)).thenReturn(ResponseEntity.ok(body));
+
+        task.execute(executionInfo);
+
+        verify(caseLevelAllDocumentsAnswerService).upsert(eq(caseId), eq(queryId), anyString(), anyString(), eq(transactionId));
+    }
+
+    @Test
+    void shouldPassRagTransactionId_toDefendantAnswerService_forDefendantLevelQuery() {
+        final UUID defendantId = UUID.randomUUID();
+        final JsonObject jobData = createObjectBuilder(executionInfo.getJobData())
+                .add(CTX_QUERY_LEVEL, QueryLevel.DEFENDANT.name())
+                .add(CTX_DEFENDANT_ID_KEY, defendantId.toString())
+                .build();
+        executionInfo = ExecutionInfo.executionInfo().from(executionInfo).withJobData(jobData).build();
+
+        when(body.getStatus()).thenReturn(ANSWER_GENERATED);
+        when(body.getLlmResponse()).thenReturn("llmResponse");
+        when(body.getDocumentChunks()).thenReturn(List.of());
+        when(api.answerUserQueryStatus(transactionId.toString(), true)).thenReturn(ResponseEntity.ok(body));
+
+        task.execute(executionInfo);
+
+        verify(defendantAnswerService).upsert(eq(caseId), eq(queryId), eq(defendantId), anyString(), anyString(), eq(documentId), eq(transactionId));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/AnswerGenerationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/AnswerGenerationServiceTest.java
@@ -48,12 +48,14 @@ public class AnswerGenerationServiceTest {
     private UUID caseId;
     private UUID queryId;
     private UUID docId;
+    private UUID ragTransactionId;
 
     @BeforeEach
     void setUp() {
         caseId = randomUUID();
         queryId = randomUUID();
         docId = randomUUID();
+        ragTransactionId = randomUUID();
     }
 
     @Test
@@ -66,7 +68,7 @@ public class AnswerGenerationServiceTest {
                 .thenReturn(1);
 
         // when
-        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId);
+        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId, ragTransactionId);
 
         // then
         final InOrder inOrder = inOrder(jdbcTemplate);
@@ -97,7 +99,7 @@ public class AnswerGenerationServiceTest {
                 .thenReturn(1);
 
         // when
-        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId);
+        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).queryForObject(anyString(), paramCaptor.capture(), eq(Integer.class));
@@ -118,7 +120,7 @@ public class AnswerGenerationServiceTest {
                 .thenReturn(1);
 
         // when
-        service.upsertAnswer(caseId, queryId, "my-answer", "my-llm-input", docId);
+        service.upsertAnswer(caseId, queryId, "my-answer", "my-llm-input", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).update(eq(SQL_UPSERT_ANSWER), paramCaptor.capture());
@@ -131,6 +133,7 @@ public class AnswerGenerationServiceTest {
         assertThat(params.getValue("answer")).isEqualTo("my-answer");
         assertThat(params.getValue("llm_input")).isEqualTo("my-llm-input");
         assertThat(params.getValue("version")).isEqualTo(5);
+        assertThat(params.getValue("rag_transaction_id")).isEqualTo(ragTransactionId);
     }
 
     @Test
@@ -141,7 +144,7 @@ public class AnswerGenerationServiceTest {
 
         // when & then
         RuntimeException ex = assertThrows(RuntimeException.class,
-                () -> service.upsertAnswer(caseId, queryId, "a", "b", docId));
+                () -> service.upsertAnswer(caseId, queryId, "a", "b", docId, ragTransactionId));
 
         assertThat(ex.getMessage()).isEqualTo("DB error");
 
@@ -160,7 +163,7 @@ public class AnswerGenerationServiceTest {
 
         // when & then
         RuntimeException ex = assertThrows(RuntimeException.class,
-                () -> service.upsertAnswer(caseId, queryId, "a", "b", docId));
+                () -> service.upsertAnswer(caseId, queryId, "a", "b", docId, ragTransactionId));
 
         assertThat(ex.getMessage()).isEqualTo("Insert failed");
     }
@@ -173,7 +176,7 @@ public class AnswerGenerationServiceTest {
         when(jdbcTemplate.update(eq(SQL_UPSERT_ANSWER), any(MapSqlParameterSource.class))).thenReturn(1);
 
         // when
-        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId);
+        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId, ragTransactionId);
 
         // then
         String versionSql = sqlCaptor.getValue();
@@ -194,7 +197,7 @@ public class AnswerGenerationServiceTest {
         when(jdbcTemplate.update(eq(SQL_UPSERT_ANSWER), any(MapSqlParameterSource.class))).thenReturn(1);
 
         // when
-        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId);
+        service.upsertAnswer(caseId, queryId, "answer", "llmInput", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate, times(2)).update(anyString(), paramCaptor.capture());

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/CaseLevelAllDocumentsAnswerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/CaseLevelAllDocumentsAnswerServiceTest.java
@@ -35,11 +35,13 @@ class CaseLevelAllDocumentsAnswerServiceTest {
 
     private UUID caseId;
     private UUID queryId;
+    private UUID ragTransactionId;
 
     @BeforeEach
     void setUp() {
         caseId = UUID.randomUUID();
         queryId = UUID.randomUUID();
+        ragTransactionId = UUID.randomUUID();
     }
 
     @Test
@@ -49,7 +51,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         when(jdbcTemplate.update(anyString(), any(MapSqlParameterSource.class))).thenReturn(1);
 
         // when
-        service.upsert(caseId, queryId, "answer", "llm-input");
+        service.upsert(caseId, queryId, "answer", "llm-input", ragTransactionId);
 
         // then
         verify(jdbcTemplate, times(1)).queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class));
@@ -63,7 +65,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
 
         // when
-        service.upsert(caseId, queryId, "ans", "llm");
+        service.upsert(caseId, queryId, "ans", "llm", ragTransactionId);
 
         // then
         verify(jdbcTemplate).update(contains("INSERT INTO case_level_all_documents_answers"), captor.capture());
@@ -74,6 +76,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         assertThat(params.getValue("version")).isEqualTo(5);
         assertThat(params.getValue("answer")).isEqualTo("ans");
         assertThat(params.getValue("llm_input")).isEqualTo("llm");
+        assertThat(params.getValue("rag_transaction_id")).isEqualTo(ragTransactionId);
     }
 
     @Test
@@ -82,7 +85,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(1);
 
         // when
-        service.upsert(caseId, queryId, "answer", "input");
+        service.upsert(caseId, queryId, "answer", "input", ragTransactionId);
 
         // then
         InOrder inOrder = inOrder(jdbcTemplate);
@@ -96,7 +99,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(null);
 
         // when / then
-        assertThrows(NullPointerException.class, () -> service.upsert(caseId, queryId, "a", "b"));
+        assertThrows(NullPointerException.class, () -> service.upsert(caseId, queryId, "a", "b", ragTransactionId));
     }
 
     @Test
@@ -107,7 +110,7 @@ class CaseLevelAllDocumentsAnswerServiceTest {
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
 
         // when
-        service.upsert(caseId, queryId, "a", "b");
+        service.upsert(caseId, queryId, "a", "b", ragTransactionId);
 
         // then
         verify(jdbcTemplate).queryForObject(contains("SELECT COALESCE(MAX(version)"), captor.capture(), eq(Integer.class));

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/CaseLevelLatestDocumentAnswerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/CaseLevelLatestDocumentAnswerServiceTest.java
@@ -36,12 +36,14 @@ class CaseLevelLatestDocumentAnswerServiceTest {
     private UUID caseId;
     private UUID queryId;
     private UUID docId;
+    private UUID ragTransactionId;
 
     @BeforeEach
     void setUp() {
         caseId = UUID.randomUUID();
         queryId = UUID.randomUUID();
         docId = UUID.randomUUID();
+        ragTransactionId = UUID.randomUUID();
     }
 
     @Test
@@ -50,7 +52,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(1);
 
         // when
-        service.upsert(caseId, queryId, "answer", "llm-input", docId);
+        service.upsert(caseId, queryId, "answer", "llm-input", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate, times(1)).queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class));
@@ -64,7 +66,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
 
         // when
-        service.upsert(caseId, queryId, "ans", "llm", docId);
+        service.upsert(caseId, queryId, "ans", "llm", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).update(contains("INSERT INTO case_level_latest_doc_answers"), captor.capture());
@@ -77,6 +79,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         assertThat(params.getValue("answer")).isEqualTo("ans");
         assertThat(params.getValue("llm_input")).isEqualTo("llm");
         assertThat(params.getValue("doc_id")).isEqualTo(docId);
+        assertThat(params.getValue("rag_transaction_id")).isEqualTo(ragTransactionId);
     }
 
     @Test
@@ -86,7 +89,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
 
         // when
-        service.upsert(caseId, queryId, "a", "b", docId);
+        service.upsert(caseId, queryId, "a", "b", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).queryForObject(contains("SELECT COALESCE(MAX(version)"), captor.capture(), eq(Integer.class));
@@ -103,7 +106,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(null);
 
         // when / then
-        assertThrows(NullPointerException.class, () -> service.upsert(caseId, queryId, "a", "b", docId));
+        assertThrows(NullPointerException.class, () -> service.upsert(caseId, queryId, "a", "b", docId, ragTransactionId));
     }
 
     @Test
@@ -112,7 +115,7 @@ class CaseLevelLatestDocumentAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(2);
 
         // when
-        service.upsert(caseId, queryId, "answer", "llm", docId);
+        service.upsert(caseId, queryId, "answer", "llm", docId, ragTransactionId);
 
         // then
         final InOrder inOrder = inOrder(jdbcTemplate);

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DefendantAnswerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DefendantAnswerServiceTest.java
@@ -38,6 +38,7 @@ class DefendantAnswerServiceTest {
     private UUID queryId;
     private UUID defendantId;
     private UUID docId;
+    private UUID ragTransactionId;
 
     @BeforeEach
     void setUp() {
@@ -45,6 +46,7 @@ class DefendantAnswerServiceTest {
         queryId = UUID.randomUUID();
         defendantId = UUID.randomUUID();
         docId = UUID.randomUUID();
+        ragTransactionId = UUID.randomUUID();
     }
 
     @Test
@@ -54,7 +56,7 @@ class DefendantAnswerServiceTest {
         when(jdbcTemplate.update(anyString(), any(MapSqlParameterSource.class))).thenReturn(1);
 
         // when
-        service.upsert(caseId, queryId, defendantId, "answer", "llmInput", docId);
+        service.upsert(caseId, queryId, defendantId, "answer", "llmInput", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class));
@@ -70,7 +72,7 @@ class DefendantAnswerServiceTest {
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
 
         // when
-        service.upsert(caseId, queryId, defendantId, "myAnswer", "myInput", docId);
+        service.upsert(caseId, queryId, defendantId, "myAnswer", "myInput", docId, ragTransactionId);
 
         // then
         verify(jdbcTemplate).update(contains("INSERT INTO defendant_answers"), captor.capture());
@@ -83,6 +85,7 @@ class DefendantAnswerServiceTest {
         assertThat(params.getValue("answer")).isEqualTo("myAnswer");
         assertThat(params.getValue("llm_input")).isEqualTo("myInput");
         assertThat(params.getValue("doc_id")).isEqualTo(docId);
+        assertThat(params.getValue("rag_transaction_id")).isEqualTo(ragTransactionId);
     }
 
     @Test
@@ -92,7 +95,7 @@ class DefendantAnswerServiceTest {
 
         // when
 
-        service.upsert(caseId, queryId, defendantId, "answer", "input", docId);
+        service.upsert(caseId, queryId, defendantId, "answer", "input", docId, ragTransactionId);
 
         // then
         final InOrder inOrder = inOrder(jdbcTemplate);
@@ -106,7 +109,7 @@ class DefendantAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(7);
 
         // when
-        service.upsert(caseId, queryId, defendantId, "answer", "input", docId);
+        service.upsert(caseId, queryId, defendantId, "answer", "input", docId, ragTransactionId);
 
         // then
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);
@@ -125,7 +128,7 @@ class DefendantAnswerServiceTest {
         when(jdbcTemplate.queryForObject(anyString(), any(MapSqlParameterSource.class), eq(Integer.class))).thenReturn(2);
 
         // when
-        service.upsert(caseId, queryId, defendantId, "answer", "input", null);
+        service.upsert(caseId, queryId, defendantId, "answer", "input", null, ragTransactionId);
 
         // then
         final ArgumentCaptor<MapSqlParameterSource> captor = ArgumentCaptor.forClass(MapSqlParameterSource.class);

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/mapper/AnswerMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/mapper/AnswerMapperTest.java
@@ -27,7 +27,7 @@ class AnswerMapperTest {
         final UUID caseId = randomUUID();
         final UUID queryId = randomUUID();
         final AnswerId answerId = new AnswerId(caseId, queryId, 2);
-        final Answer answer = new Answer(answerId, utcNow(), testAnswer, llmText, randomUUID());
+        final Answer answer = new Answer(answerId, utcNow(), testAnswer, llmText, randomUUID(), randomUUID());
 
         // When
         final AnswerResponse response = mapper.toAnswerResponse(answer, userQuery);
@@ -49,7 +49,7 @@ class AnswerMapperTest {
         final UUID caseId = randomUUID();
         final UUID queryId = randomUUID();
         final AnswerId answerId = new AnswerId(caseId, queryId, 2);
-        final Answer answer = new Answer(answerId, utcNow(), testAnswer, llmText, randomUUID());
+        final Answer answer = new Answer(answerId, utcNow(), testAnswer, llmText, randomUUID(), randomUUID());
 
         // When
         final AnswerWithLlmResponse response = mapper.toAnswerWithLlm(answer, userQuery);


### PR DESCRIPTION
## Summary
- `CheckStatusOfAnswerGenerationTask` already resolves the RAG `transactionId` to poll answer status, but dropped it before persisting the answer — RAG-provenance data was silently discarded across all four answer tables.
- Adds a nullable `rag_transaction_id UUID` column to `answers`, `case_level_latest_doc_answers`, `case_level_all_documents_answers`, and `defendant_answers` via `V1012` (append-only, no backfill).
- Threads the already-resolved `transactionId` through `TaskUtils.buildAnswerParams` and all four answer-service upsert methods (`AnswerGenerationService`, `CaseLevelLatestDocumentAnswerService`, `CaseLevelAllDocumentsAnswerService`, `DefendantAnswerService`), written on both `INSERT` and `ON CONFLICT ... DO UPDATE SET`.
- Adds a mapped `ragTransactionId` field to `Answer`/`BaseAnswer` for read-side entity/schema parity — no API/contract change (`AnswerMapper`, `AnswerResponse`, `AnswerWithLlmResponse`, `version.cdk` all untouched).
- Full requirements/design/ADR/story pipeline docs under `docs/pipeline/DD-43084-persist-rag-transaction-id/` and `docs/pipeline/adrs/DD-43084-persist-rag-transaction-id.md`.

## Test plan
- [x] `./gradlew compileJava compileTestJava` — clean
- [x] `./gradlew test` (targeted + full suite) — green, including Testcontainers-backed repo tests, which exercised the new `V1012` migration against real Postgres with no errors
- [x] `./gradlew pmdMain pmdTest` — clean
- [x] `./gradlew jacocoTestCoverageVerification` — passes at existing thresholds
- [ ] `./gradlew integration` — **not run**: Docker was not reachable in the environment this PR was authored in (`composeBuild` failed to spawn the `docker` process). Needs to be run in CI/locally before merge, per this repo's "integration tests are not optional" rule.
- [ ] No end-to-end integration test exists yet that drives `GenerateAnswerForQueryTask` → `CheckStatusOfAnswerGenerationTask` fully through the compose stack to assert the persisted column value — flagged as a follow-up in `02-design.md`'s Testing section; unit coverage (SQL param capture) is what verifies this change today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)