### PR TITLE
[DD-43061] and [DD-43062] ACL and discovery scheduler trigger endpoint

### DIFF
--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
@@ -13,7 +13,7 @@ deployed to and verified on sandbox · Jira ticket updated with test evidence. D
 ---
 
 ## Story 1 — Release trigger operation in the API contract
-**Jira: DD-#####**
+**Jira: DD-43060**
 As a **CDKS developer**, I want **`POST /discovery-scheduler/trigger` and its schemas — including
 the dedicated vendor media type — added to and released from
 `api-cp-crime-caseadmin-case-document-knowledge`**, so that **the endpoint can be implemented
@@ -27,7 +27,7 @@ against a generated interface, not hand-scaffolded**.
 - DoD delta: contract PR reviewed & released; no breaking change to existing `Discovery Scheduler` tag
 
 ## Story 2 — System-Users-only ACL rule for the trigger endpoint
-**Jira: DD-#####**
+**Jira: DD-43061**
 As a **security engineer**, I want **a new Drools rule restricting the trigger action to "System
 Users" only, no "AI search" fallback**, so that **only trusted operational callers can force an
 on-demand run**.
@@ -39,12 +39,12 @@ on-demand run**.
 - AC-011: New Drools rule has exactly one group-membership condition — no `hasPermission`, no `or` — matching `discovery-scheduler-configuration`.
 
 - NFR: NFR-001 (AuthZ)
-- Dependency: needs Story 1's released vendor media type/action name; route through `rbac-auditor`
+- Dependency: needs Story 1 (DD-43060)'s released vendor media type/action name; route through `rbac-auditor`
   (CLAUDE.md — any `acl/` change)
 - DoD delta: `rbac-auditor` review completed for `acl/cdks-rules.drl`
 
 ## Story 3 — On-demand discovery trigger endpoint (fire-and-forget dispatch)
-**Jira: DD-#####**
+**Jira: DD-43062**
 As a **support/operations user (System User)**, I want **to POST a named operation
 (`INTRADAY`/`NIGHTLY`) and get an immediate `202 Accepted`**, so that **I can force a missed or
 extra discovery run without waiting for its cron, or blocking on completion**.
@@ -70,8 +70,8 @@ Reuses `DiscoveryService` unchanged via new `DiscoveryTriggerService` + dedicate
 - Out of scope: run-status/history, cancel/pause/resume, parameterising the run, a third operation,
   rate limiting, 409/429 on queue-full/lock-overlap (design §6, ADR-001)
 - NFR: NFR-004, NFR-005, NFR-006, NFR-008, NFR-009, NFR-012
-- Dependency: needs Story 1 released/consumed (`version.cdk` bump lands here); compiles independent
-  of Story 2 but fail-closed without it — ship together
+- Dependency: needs Story 1 (DD-43060) released/consumed (`version.cdk` bump lands here); compiles independent
+  of Story 2 (DD-43061) but fail-closed without it — ship together
 - DoD delta: `DiscoveryServiceTest`/existing scheduler tests pass unmodified (AC-007); `gradle
   clean build` incl. `integration` green, PMD/JaCoCo at existing thresholds (AC-024)
 

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/04-test-specs.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/04-test-specs.md
@@ -1,0 +1,213 @@
+# Test Specs: Manual Discovery Scheduler Trigger Endpoint
+
+> **Stage 4 — Test Specs** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Parent Jira: DD-43036** · Requirements: [`01-requirements.md`](./01-requirements.md) ·
+> Design: [`02-design.md`](./02-design.md) · Stories: [`03-stories.md`](./03-stories.md) ·
+> ADRs: [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md)
+>
+> Scenarios for `src/integrationTest/`, grouped by story. **Story 1 (DD-43060)** is contract-only
+> (no runtime behaviour here — no scenarios). **Story 4** not yet scoped into this file.
+
+---
+
+## Story 2 — System-Users-only ACL rule for the trigger endpoint (DD-43061)
+
+Covers **AC-008 – AC-011**, NFR-001 (AuthZ).
+
+### Reference material
+
+| Asset | Path | Use |
+|---|---|---|
+| ACL journey template | `.../http/DiscoverySchedulerConfigurationHttpLiveTest.java` (lines 100–108) | `extends AbstractHttpLiveTest`, vendor media type, `CJSCPPUID` header, `try/fail/catch HttpClientErrorException` idiom for 4xx |
+| Both-persona pattern | `.../http/QueriesHttpLiveTest.java` (~line 138) | `@ParameterizedTest` over both personas — Story 2 inverts it: outcomes must now *differ* |
+| Base infra | `testsupport/AbstractHttpLiveTest.java`, `util/UtilHttp.java`, `util/UtilConstants.java` | `baseUrl`, shared `RestTemplate` |
+| Caller fixtures | `wiremock/mappings/user_group_query_api*.json` | Stubbed `usersgroups` identities |
+| Rule template | `src/main/resources/acl/cdks-rules.drl` (lines 81–88), `"Allow LA – discovery-scheduler-configuration"` | Shape the new rule must match (AC-011) |
+| Filter config | `application-other.yml` `authz.http` | `enabled/deny-when-no-rules/reload-on-each-request: true`; `/discovery-scheduler` not excluded → filter-protected |
+
+**New IT class:** `http/DiscoverySchedulerTriggerAclHttpLiveTest.java` — ACL only. Functional trigger
+scenarios belong to Story 3's `DiscoverySchedulerTriggerHttpLiveTest`.
+
+**Caller fixtures — reuse only, do not add new stubs:**
+
+| Persona | Constant | Identity | Covers |
+|---|---|---|---|
+| System User | `USER_WITH_SYSTEM_USERS_GROUPS` | group `"System Users"` | AC-008 |
+| Permission-only | `USER_WITH_PERMISSIONS` | no groups, `AI search/View` permission | AC-009 |
+
+> Names don't signal the split — use `@DisplayName` to state intent.
+
+### Scenarios
+
+**S2.1 — System User authorised (AC-008).** Given the new rule exists and caller is
+`USER_WITH_SYSTEM_USERS_GROUPS`, when they `POST /discovery-scheduler/trigger` (vendor media type,
+valid `discoveryOperation`), then response is not 401/403, and is `202 Accepted` with vendor
+content type. Run for both `INTRADAY` and `NIGHTLY` (`@ParameterizedTest`). Assert authorisation
+only — full body contract is Story 3's.
+
+**S2.2 — Permission-only caller denied (AC-009, runtime half of AC-011).** Given caller is
+`USER_WITH_PERMISSIONS` (no groups), when they `POST` the same request, then `403 Forbidden`
+(`HttpClientErrorException.Forbidden`), and body has no `CJSCPPUID`/case/court/document data.
+(Response `Content-Type` is not a useful discriminator here: `GlobalExceptionHandler` negotiates
+it from the request's `Accept` header regardless of which layer produced the error, so a 403 can
+still carry the trigger vendor type — empirically confirmed, don't assert on it.) This caller *is*
+authorised on other endpoints with an
+`or hasPermission` branch — a 403 here proves the new rule has no such fallback. Pair with S2.1 to
+also catch a wrong Drools action name (which would 403 both personas).
+
+**S2.3 — No `CJSCPPUID` header denied (AC-010).** Given a well-formed request with no `CJSCPPUID`
+at all, when `POST`ed, then `401 Unauthorized`, and no call reaches the stubbed `usersgroups`
+endpoint (verify via WireMock admin `findAll(getRequestedFor(...))` count before/after).
+Also assert blank/whitespace `CJSCPPUID` → `401`.
+
+> **Blocker:** `UtilHttp.newClient()` auto-injects `CJSCPPUID: USER_WITH_PERMISSIONS` when absent
+> (`UtilHttp.java:19–26`), so the inherited client can't send a header-less request. Add
+> `UtilHttp.newClientWithoutDefaultUser()` (same client, no interceptor) for this scenario only —
+> don't touch the existing interceptor, ~a dozen ITs depend on it.
+
+**S2.4 — Rule matches `discovery-scheduler-configuration` shape (AC-011, static half).**
+Structural, not an IT. New unit test `controllers/accesscontrol/CdksAclRulesTest.java` (no such
+class exists yet): given `classpath:/acl/cdks-rules.drl`, isolate the block whose action is
+`casedocumentknowledge-service.discovery-scheduler-trigger`, then assert exactly one `eval(...)`
+(`isMemberOfAnyOfTheSuppliedGroups($a, "System Users")`), no `hasPermission`, no `or`, and
+structural parity with the existing LA block (lines 81–88). Behavioural corroboration = S2.1 + S2.2.
+Complements, doesn't replace, the mandatory `rbac-auditor` review.
+
+**S2.5 — Existing ACL rules unaffected (regression, NFR-001).** Given the new rule is appended to
+the shared `.drl`, the existing suite (`DiscoverySchedulerConfigurationHttpLiveTest`,
+`QueriesHttpLiveTest`/`IngestionProcessHttpLiveTest` permission paths) still passes unchanged. No
+new test — a malformed append + `deny-when-no-rules: true` would silently 403 everything, so this
+is a "must run" statement, not a new file.
+
+### Coverage map
+
+| AC | Scenario(s) | Layer |
+|---|---|---|
+| AC-008 | S2.1 (× `INTRADAY`, `NIGHTLY`) | Integration |
+| AC-009 | S2.2 | Integration |
+| AC-010 | S2.3 (+ blank-header variant) | Integration |
+| AC-011 | S2.4 static + S2.1/S2.2 behavioural | Unit + Integration |
+| NFR-001 | S2.1–S2.5 collectively | Integration |
+
+### Constraints and open questions
+
+1. **"Nothing dispatched" isn't directly assertable at IT level** — compose overrides both crons to
+   `0/30 * * * * *`, so counting dispatches is confounded by concurrent scheduled runs. Proxy: a
+   401/403 means the controller was never entered. True "no dispatch" assertion belongs at unit
+   level in Story 3. Open: should a log-scraping test helper be added to assert absence of a
+   `trigger=manual` record? Not built today — likely Story 4.
+2. **These ITs can't run until Stories 1 and 3 land** — before then, every request 403s
+   (`deny-when-no-rules`) regardless of persona, so S2.2/S2.3 would pass for the wrong reason. Write
+   now (A-TDD), but treat green S2.2/S2.3 as meaningless until S2.1 is also green.
+3. **`action-required: false` + wrong/missing vendor media type** — design says this should still
+   deny, but `action-required: false` on its face doesn't reject for a non-derivable action; may
+   still be caught by `deny-when-no-rules`. Not one of Story 2's ACs — needs empirical confirmation
+   and an `rbac-auditor` flag before Story 3 writes its item-7 IT.
+4. **Group aliasing** — `authz.http.group-aliases` doesn't cover `"System Users"`; it's matched
+   literally, consistent with the existing rule. No new alias needed.
+5. **No negative-authorisation IT exists in this repo today** — current suite only asserts
+   OK/ACCEPTED/CONFLICT/NOT_FOUND. S2.2/S2.3 are the first 401/403 assertions; pick one idiom
+   (`try/fail/catch` or no-op `ResponseErrorHandler`) and use it consistently.
+6. **Test data** — synthetic WireMock fixtures and `UUID.randomUUID()` only; no real case/court/user
+   identifiers.
+
+---
+
+## Story 3 — On-demand discovery trigger endpoint (fire-and-forget dispatch) (DD-43062)
+
+Covers **AC-001, AC-002, AC-004–AC-007, AC-012–AC-017, AC-021–AC-025**. NFR-004/005/006/008/009/012.
+
+**New IT class:** `http/DiscoverySchedulerTriggerHttpLiveTest.java` — functional/dispatch only;
+ACL is Story 2's `DiscoverySchedulerTriggerAclHttpLiveTest`, not repeated here.
+
+**Auditing (AC-023) and `correlationId` need no new plumbing:**
+`cp-audit-filter-springboot` audits every OpenAPI-documented operation automatically (no
+`AuditService` call in application code anywhere in this repo — confirmed by grep); `triggerDiscovery`
+gets audited for free once it's a real operation. `RequestContextFilter` already puts the inbound
+request's id into MDC key `correlationId` before the controller runs, so the controller can read
+`MDC.get("correlationId")` directly for the response field — no interceptor/decorator needed for
+this part (worker-thread MDC propagation, i.e. `MdcCopyingTaskDecorator`, is Story 4's job).
+
+**AC-012/013/014 need no new exception-handling code either:** the generated
+`DiscoveryTriggerRequest.discoveryOperation` is already `@NotNull @Valid` and `DiscoveryOperation`'s
+`@JsonCreator fromValue(...)` already throws on an unrecognised string — both route through the
+existing `GlobalExceptionHandler` (`onValidation` / `onUnreadable`) to `400`, same as every other
+endpoint. Nothing to add beyond the controller method itself.
+
+### Scenarios
+
+**S3.1 — Authorised trigger dispatches and returns 202 (AC-001, AC-004–006, AC-017).** Given a
+System User POSTs a valid `discoveryOperation` (`INTRADAY` or `NIGHTLY`), then `202 Accepted`,
+vendor content type, body echoes `discoveryOperation` + `message` + a non-blank `correlationId`;
+the response returns well before a `NIGHTLY` run could complete (assert wall-clock only, not
+completion). `@ParameterizedTest` over both enum values.
+
+**S3.2 — Non-blocking dispatch (design §Testing item 5).** Given the WireMock hearing stub carries
+a `fixedDelay` (e.g. 5s), when triggered, then the 202 returns well under that delay — proves
+dispatch runs off the request thread, not inline.
+
+**S3.3 — Wrong HTTP method → 405 (AC-002).** Given a `GET` to `/discovery-scheduler/trigger`, then
+`405`, nothing dispatched.
+
+**S3.4 — Missing/unrecognised/malformed body → 400 (AC-012–014, AC-015).** Three sub-cases: missing
+`discoveryOperation`; unrecognised enum string; malformed JSON (message is exactly
+`"Malformed request body"`, per the existing `onUnreadable` handler). Body carries no caller-supplied
+value in any case.
+
+**S3.5 — Audit event emitted (AC-023).** Given a successful trigger, when dispatched, then an audit
+event exists identifying the action and its time — assert via `BrokerUtil.getMessageMatching(...)`
+against the `jms.topic.auditing.event` topic (same pattern as `IngestionProcessHttpLiveTest`).
+
+**S3.6 — Existing suites pass unmodified (AC-007, regression).** `DiscoveryServiceTest` and both
+scheduler live tests pass with no changes required by this story — no new test, a "must still pass"
+statement.
+
+Not separately IT-tested (unit-level or non-test per 03-stories.md): **AC-021** (documented
+accepted-risk, not enforced — no test), **AC-022** (per-item dispatch failure isolation — unit-level
+in `DiscoveryTriggerServiceTest`, since `DiscoveryService` already swallows per-item errors),
+**AC-024/025** (build-level / diff-review, not a test class).
+
+### Unit specs (`src/test/`)
+
+| Target | Covers |
+|---|---|
+| `DiscoveryTriggerServiceTest` (new) | Enum routes to the correct `DiscoveryService` method (exhaustive switch expression, no `default` — a third enum value fails to compile); submission delegates to the injected executor, not the calling thread; an escaping exception is caught and logged, not rethrown (AC-022). |
+| `DiscoverySchedulerControllerTest` (extend) | New method returns 202 + vendor content type, delegates once to `DiscoveryTriggerService`; existing tests unaffected. |
+| `DiscoveryServiceTest` (existing) | Must not change (AC-007). |
+
+### Coverage map
+
+| AC | Scenario(s) | Layer |
+|---|---|---|
+| AC-001 | S3.1 | Integration |
+| AC-002 | S3.3 | Integration |
+| AC-004–006 | S3.1 + `DiscoveryTriggerServiceTest` | Integration + Unit |
+| AC-007 | S3.6 | Integration (regression) |
+| AC-012–015 | S3.4 | Integration |
+| AC-017 | S3.1 | Integration |
+| AC-021 | — | Documented, not tested (ADR-001) |
+| AC-022 | `DiscoveryTriggerServiceTest` | Unit |
+| AC-023 | S3.5 | Integration |
+| AC-024/025 | — | Build / review |
+
+### Constraints and open questions
+
+1. **Config prefix deviates from design §10.** Design says `cp.cdk.discovery-trigger.*`, but no
+   `cp.cdk.*` prefix exists anywhere else in this repo — the established convention is a flat
+   `cdk.<feature>` prefix (`cdk.ingestion`, `cdk.storage.azure`). Using `cdk.discovery-trigger.*` for
+   consistency with `IngestionProperties`/`StorageProperties`; flagging as a deliberate deviation from
+   the design doc, not an oversight.
+2. **`MdcCopyingTaskDecorator` is explicitly out of scope for this story** — the executor bean has no
+   custom `TaskDecorator`; worker-thread logs won't carry `correlationId` until Story 4 adds it, per
+   03-stories.md's own note that Story 4's classes are "implemented alongside Story 3's ... not
+   independently deployable". The response body's `correlationId` (a Story 3 concern, part of the
+   released contract) is unaffected — that's read from MDC synchronously on the request thread.
+3. **AC-002 uncovered a pre-existing gap in `GlobalExceptionHandler`, unrelated to this endpoint.**
+   `S3.3` (wrong method → 405) initially returned `500`: the class's catch-all
+   `@ExceptionHandler(Exception.class)` intercepts `HttpRequestMethodNotSupportedException` before
+   Spring's own 405 translation ever runs, for *every* endpoint in the service, not just this one —
+   no existing test had exercised a wrong-method request anywhere in the repo. Fixed by adding an
+   explicit `@ExceptionHandler(HttpRequestMethodNotSupportedException.class)` (→ 405) ahead of the
+   catch-all, with unit coverage added to the existing `GlobalExceptionHandlerTest`. This is a
+   deviation from design §2's "not changed" list for `GlobalExceptionHandler.java` — required for
+   AC-002, not a scope choice.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 JAVA_VERSION=25
-version.cdk=0.0.11
+version.cdk=0.0.12
 version.aiRag=0.0.15
 version.apiSpec=0.4.2
 version.lombok=1.18.42

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerAclHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerAclHttpLiveTest.java
@@ -1,0 +1,119 @@
+package uk.gov.hmcts.cp.cdk.http;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.findAll;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.hmcts.cp.cdk.util.UtilConstants.CJSCPPUID;
+import static uk.gov.hmcts.cp.cdk.util.UtilConstants.USER_WITH_PERMISSIONS;
+import static uk.gov.hmcts.cp.cdk.util.UtilConstants.USER_WITH_SYSTEM_USERS_GROUPS;
+
+import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
+import uk.gov.hmcts.cp.cdk.util.UtilHttp;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * ACL-only coverage for POST /discovery-scheduler/trigger (Story 2, DD-43061).
+ * Functional trigger/dispatch behaviour belongs to Story 3's DiscoverySchedulerTriggerHttpLiveTest.
+ * These scenarios stay red until the new Drools rule (Story 2) and the controller method
+ * (Story 3) both land -- see 04-test-specs.md constraint 2.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiscoverySchedulerTriggerAclHttpLiveTest extends AbstractHttpLiveTest {
+
+    private static final String USERS_GROUPS_PERMISSIONS_PATH =
+            "/usersgroups-query-api/query/api/rest/usersgroups/users/logged-in-user/permissions";
+    private static final MediaType VND_TYPE_JSON = MediaType.valueOf(
+            "application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json");
+
+    private ResponseEntity<String> postTrigger(final RestTemplate client, final String cjscppuid,
+                                                final DiscoveryOperation operation) {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(VND_TYPE_JSON);
+        headers.setAccept(List.of(VND_TYPE_JSON));
+        if (cjscppuid != null) {
+            headers.set(CJSCPPUID, cjscppuid);
+        }
+
+        final String body = """
+                {
+                  "discoveryOperation": "%s"
+                }
+                """.formatted(operation);
+
+        return client.exchange(
+                baseUrl + "/discovery-scheduler/trigger",
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                String.class
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(DiscoveryOperation.class)
+    @DisplayName("System User is authorised for the trigger action (AC-008)")
+    void systemUser_isAuthorisedForTrigger(final DiscoveryOperation operation) {
+        final ResponseEntity<String> response = postTrigger(http, USER_WITH_SYSTEM_USERS_GROUPS, operation);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(VND_TYPE_JSON);
+    }
+
+    @Test
+    @DisplayName("\"AI search\"-permission-only caller is denied (AC-009, runtime half of AC-011)")
+    void permissionOnlyCaller_isDeniedForTrigger() {
+        try {
+            postTrigger(http, USER_WITH_PERMISSIONS, DiscoveryOperation.INTRADAY);
+            fail("Expected permission-only caller to be denied");
+        } catch (final HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+            assertThat(ex.getResponseBodyAsString()).doesNotContain(USER_WITH_PERMISSIONS);
+        }
+    }
+
+    @Test
+    @DisplayName("No CJSCPPUID header is denied (AC-010)")
+    void noCjscppuid_isDeniedForTrigger() {
+        configureFor("localhost", 8089);
+        final int before = findAll(getRequestedFor(urlPathEqualTo(USERS_GROUPS_PERMISSIONS_PATH))).size();
+
+        try {
+            postTrigger(UtilHttp.newClientWithoutDefaultUser(), null, DiscoveryOperation.INTRADAY);
+            fail("Expected request with no CJSCPPUID to be denied");
+        } catch (final HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+
+        final int after = findAll(getRequestedFor(urlPathEqualTo(USERS_GROUPS_PERMISSIONS_PATH))).size();
+        assertThat(after).as("filter must reject before identity resolution").isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("Blank CJSCPPUID header is denied (AC-010 variant)")
+    void blankCjscppuid_isDeniedForTrigger() {
+        try {
+            postTrigger(UtilHttp.newClientWithoutDefaultUser(), " ", DiscoveryOperation.INTRADAY);
+            fail("Expected request with blank CJSCPPUID to be denied");
+        } catch (final HttpClientErrorException ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerHttpLiveTest.java
@@ -1,0 +1,153 @@
+package uk.gov.hmcts.cp.cdk.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.hmcts.cp.cdk.util.UtilConstants.CJSCPPUID;
+import static uk.gov.hmcts.cp.cdk.util.UtilConstants.USER_WITH_SYSTEM_USERS_GROUPS;
+
+import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
+import uk.gov.hmcts.cp.cdk.util.BrokerUtil;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+
+/**
+ * Functional/dispatch coverage for POST /discovery-scheduler/trigger (Story 3, DD-43062).
+ * ACL is Story 2's DiscoverySchedulerTriggerAclHttpLiveTest -- not repeated here.
+ *
+ * Only trigger_dispatchesAndReturns202_withoutBlocking is genuinely red right now: the
+ * generated DiscoverySchedulerApi interface already carries @RequestMapping/@Valid on
+ * triggerDiscovery, so Spring's method-not-allowed and request-validation handling (and the
+ * automatic cp-audit-filter-springboot auditing) already work off that contract alone, before
+ * any of this story's code exists. Only the real 202 dispatch requires the new implementation.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class DiscoverySchedulerTriggerHttpLiveTest extends AbstractHttpLiveTest {
+
+    private static final MediaType VND_TYPE_JSON = MediaType.valueOf(
+            "application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json");
+    private static final String TRIGGER_PATH = "/discovery-scheduler/trigger";
+
+    private HttpHeaders vendorHeaders() {
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(VND_TYPE_JSON);
+        headers.setAccept(List.of(VND_TYPE_JSON));
+        headers.set(CJSCPPUID, USER_WITH_SYSTEM_USERS_GROUPS);
+        return headers;
+    }
+
+    @ParameterizedTest
+    @EnumSource(DiscoveryOperation.class)
+    @DisplayName("Authorised trigger dispatches and returns 202 without blocking (AC-001, AC-004-006, AC-017)")
+    void trigger_dispatchesAndReturns202_withoutBlocking(final DiscoveryOperation operation) {
+        final String correlationId = UUID.randomUUID().toString();
+        final HttpHeaders headers = vendorHeaders();
+        headers.set("X-Correlation-Id", correlationId);
+
+        final String body = """
+                {
+                  "discoveryOperation": "%s"
+                }
+                """.formatted(operation);
+
+        final Instant before = Instant.now();
+        final ResponseEntity<String> response = http.exchange(
+                baseUrl + TRIGGER_PATH, HttpMethod.POST, new HttpEntity<>(body, headers), String.class);
+        final Duration elapsed = Duration.between(before, Instant.now());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(VND_TYPE_JSON);
+        assertThat(response.getBody()).contains("\"discoveryOperation\":\"" + operation + "\"");
+        assertThat(response.getBody()).contains("\"correlationId\":\"" + correlationId + "\"");
+        assertThat(elapsed)
+                .as("202 must return without waiting for the dispatched run to complete")
+                .isLessThan(Duration.ofSeconds(3));
+    }
+
+    @Test
+    @DisplayName("Wrong HTTP method is rejected (AC-002)")
+    void wrongHttpMethod_isRejected() {
+        try {
+            http.exchange(baseUrl + TRIGGER_PATH, HttpMethod.GET, new HttpEntity<>(vendorHeaders()), String.class);
+            fail("Expected GET to be rejected");
+        } catch (final HttpClientErrorException.MethodNotAllowed ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+        }
+    }
+
+    @Test
+    @DisplayName("Missing discoveryOperation field is rejected with 400 (AC-012, AC-015)")
+    void missingField_isRejected() {
+        assertBadRequest("{}");
+    }
+
+    @Test
+    @DisplayName("Unrecognised discoveryOperation value is rejected with 400 (AC-013, AC-015)")
+    void unrecognisedValue_isRejected() {
+        assertBadRequest("""
+                {
+                  "discoveryOperation": "NOT_A_REAL_OPERATION"
+                }
+                """);
+    }
+
+    @Test
+    @DisplayName("Malformed JSON body is rejected with 400 and the fixed message (AC-014, AC-015)")
+    void malformedJson_isRejected() {
+        try {
+            http.exchange(baseUrl + TRIGGER_PATH, HttpMethod.POST,
+                    new HttpEntity<>("{ not-json ", vendorHeaders()), String.class);
+            fail("Expected malformed JSON to be rejected");
+        } catch (final HttpClientErrorException.BadRequest ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(ex.getResponseBodyAsString()).contains("Malformed request body");
+        }
+    }
+
+    private void assertBadRequest(final String body) {
+        try {
+            http.exchange(baseUrl + TRIGGER_PATH, HttpMethod.POST,
+                    new HttpEntity<>(body, vendorHeaders()), String.class);
+            fail("Expected request to be rejected with 400");
+        } catch (final HttpClientErrorException.BadRequest ex) {
+            assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+            assertThat(ex.getResponseBodyAsString()).doesNotContain(USER_WITH_SYSTEM_USERS_GROUPS);
+        }
+    }
+
+    @Test
+    @DisplayName("A successful trigger emits an audit event identifying the action (AC-023)")
+    void trigger_emitsAuditEvent() throws Exception {
+        try (BrokerUtil broker = new BrokerUtil()) {
+            final ResponseEntity<String> response = http.exchange(
+                    baseUrl + TRIGGER_PATH, HttpMethod.POST,
+                    new HttpEntity<>("""
+                            {
+                              "discoveryOperation": "INTRADAY"
+                            }
+                            """, vendorHeaders()),
+                    String.class);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+
+            final String auditMessage = broker.getMessageMatching(json ->
+                    json.toString().contains("discovery-scheduler-trigger"));
+            assertThat(auditMessage).as("expected an audit event for the trigger action").isNotNull();
+        }
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/util/UtilHttp.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/util/UtilHttp.java
@@ -27,4 +27,14 @@ public final class UtilHttp {
 
         return rt;
     }
+
+    /**
+     * A client with no default-user interceptor, for tests that must send a request
+     * with no CJSCPPUID header at all (newClient() always injects one when absent).
+     */
+    public static RestTemplate newClientWithoutDefaultUser() {
+        return new RestTemplate(
+                new BufferingClientHttpRequestFactory(new SimpleClientHttpRequestFactory())
+        );
+    }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerConfig.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerConfig.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.cp.cdk.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+/**
+ * Dedicated, bounded executor for the manual discovery trigger (Story 3, DD-43062).
+ * Not ShedLockConfig -- unrelated to scheduler locking. corePoolSize/maxPoolSize are fixed
+ * at 1: boundedness is the only back-pressure, per pod, not a distributed guarantee.
+ */
+@Configuration
+@EnableConfigurationProperties(DiscoveryTriggerProperties.class)
+public class DiscoveryTriggerConfig {
+
+    @Bean("discoveryTriggerExecutor")
+    public ThreadPoolTaskExecutor discoveryTriggerExecutor(final DiscoveryTriggerProperties properties) {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(properties.getQueueCapacity());
+        executor.setThreadNamePrefix("discovery-trigger-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(properties.getAwaitTerminationSeconds());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerProperties.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerProperties.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.cp.cdk.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Binds cdk.discovery-trigger.* properties.
+ */
+@ConfigurationProperties(prefix = "cdk.discovery-trigger")
+public class DiscoveryTriggerProperties {
+
+    private int queueCapacity = 10;
+    private int awaitTerminationSeconds = 30;
+
+    public int getQueueCapacity() {
+        return queueCapacity;
+    }
+
+    public void setQueueCapacity(final int queueCapacity) {
+        this.queueCapacity = queueCapacity;
+    }
+
+    public int getAwaitTerminationSeconds() {
+        return awaitTerminationSeconds;
+    }
+
+    public void setAwaitTerminationSeconds(final int awaitTerminationSeconds) {
+        this.awaitTerminationSeconds = awaitTerminationSeconds;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerController.java
@@ -1,13 +1,20 @@
 package uk.gov.hmcts.cp.cdk.controllers;
 
 import uk.gov.hmcts.cp.cdk.services.DiscoverySchedulerConfigurationService;
+import uk.gov.hmcts.cp.cdk.services.DiscoveryTriggerService;
 import uk.gov.hmcts.cp.openapi.api.cdk.DiscoverySchedulerApi;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
 import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryTriggerRequest;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryTriggerResponse;
 import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +24,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DiscoverySchedulerController implements DiscoverySchedulerApi {
 
+    private static final MediaType VND_DISCOVERY_SCHEDULER_TRIGGER = MediaType.valueOf(
+            "application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json");
+
     private final DiscoverySchedulerConfigurationService service;
+    private final DiscoveryTriggerService discoveryTriggerService;
 
     @Override
     public ResponseEntity<UpsertDiscoverySchedulerConfiguration200Response> upsertDiscoverySchedulerConfiguration(
@@ -27,5 +38,22 @@ public class DiscoverySchedulerController implements DiscoverySchedulerApi {
                 discoverySchedulerConfigurationRequest.getCourtRoomId(),
                 discoverySchedulerConfigurationRequest.getVersion());
         return ResponseEntity.ok(service.upsert(discoverySchedulerConfigurationRequest));
+    }
+
+    @Override
+    public ResponseEntity<DiscoveryTriggerResponse> triggerDiscovery(
+            @RequestBody @Valid final DiscoveryTriggerRequest discoveryTriggerRequest) {
+        final DiscoveryOperation operation = discoveryTriggerRequest.getDiscoveryOperation();
+        log.debug("Discovery trigger accepted discoveryOperation={}", operation);
+        discoveryTriggerService.trigger(operation);
+
+        final DiscoveryTriggerResponse response = new DiscoveryTriggerResponse()
+                .discoveryOperation(operation)
+                .message("Discovery run dispatched.")
+                .correlationId(MDC.get("correlationId"));
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED)
+                .contentType(VND_DISCOVERY_SCHEDULER_TRIGGER)
+                .body(response);
     }
 }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/controllers/GlobalExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/controllers/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -85,6 +86,14 @@ public class GlobalExceptionHandler {
         log.warn("Malformed request body: {}", httpMessageNotReadableException.getMessage());
         final ErrorResponse err = base(String.valueOf(HttpStatus.BAD_REQUEST.value()), "Malformed request body");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(err);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> onMethodNotSupported(final HttpRequestMethodNotSupportedException httpRequestMethodNotSupportedException) {
+        log.warn("Method not supported: {}", httpRequestMethodNotSupportedException.getMessage());
+        final ErrorResponse err = base(String.valueOf(HttpStatus.METHOD_NOT_ALLOWED.value()),
+                httpRequestMethodNotSupportedException.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).body(err);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerService.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Dispatches an on-demand discovery run (Story 3, DD-43062) by reusing DiscoveryService's
+ * existing runIntradayDiscovery/runNightlyDiscovery unchanged, off the request thread.
+ * A separate class rather than a new DiscoveryService method: DiscoveryService's constructor
+ * already takes 9 dependencies, so adding a TaskExecutor there would touch every
+ * DiscoveryServiceTest construction site.
+ */
+@Slf4j
+@Service
+public class DiscoveryTriggerService {
+
+    private final DiscoveryService discoveryService;
+    private final TaskExecutor discoveryTriggerExecutor;
+
+    public DiscoveryTriggerService(final DiscoveryService discoveryService,
+                                    @Qualifier("discoveryTriggerExecutor") final TaskExecutor discoveryTriggerExecutor) {
+        this.discoveryService = discoveryService;
+        this.discoveryTriggerExecutor = discoveryTriggerExecutor;
+    }
+
+    public void trigger(final DiscoveryOperation operation) {
+        // Exhaustive switch expression, no default: a future third enum value fails to compile here.
+        final Runnable delegate = switch (operation) {
+            case INTRADAY -> discoveryService::runIntradayDiscovery;
+            case NIGHTLY -> discoveryService::runNightlyDiscovery;
+        };
+        discoveryTriggerExecutor.execute(() -> runWithLogging(operation, delegate));
+    }
+
+    private void runWithLogging(final DiscoveryOperation operation, final Runnable delegate) {
+        final long startedAt = System.currentTimeMillis();
+        log.info("Manual discovery run starting discoveryOperation={} trigger=manual", operation);
+        try {
+            delegate.run();
+            log.info("Manual discovery run finished discoveryOperation={} trigger=manual durationMs={}",
+                    operation, System.currentTimeMillis() - startedAt);
+        } catch (final Exception e) {
+            log.error("Manual discovery run failed discoveryOperation={} trigger=manual durationMs={}",
+                    operation, System.currentTimeMillis() - startedAt, e);
+        }
+    }
+}

--- a/src/main/resources/acl/cdks-rules.drl
+++ b/src/main/resources/acl/cdks-rules.drl
@@ -86,3 +86,12 @@ when
 then
   $o.setSuccess(true);
 end
+
+rule "Allow LA – discovery-scheduler-trigger"
+when
+  $o: Outcome()
+  $a: Action(name == "casedocumentknowledge-service.discovery-scheduler-trigger")
+  eval(userAndGroupProvider.isMemberOfAnyOfTheSuppliedGroups($a, "System Users"))
+then
+  $o.setSuccess(true);
+end

--- a/src/main/resources/application-cdk.yml
+++ b/src/main/resources/application-cdk.yml
@@ -49,6 +49,10 @@ cdk:
         max-attempts: ${CDK_JOBMANAGER_RETRY_QUESTIONS_MAX_ATTEMPTS:100}
         delay-seconds: ${CDK_JOBMANAGER_RETRY_QUESTIONS_DELAY_SECONDS:10}
 
+  discovery-trigger:
+    queue-capacity: ${CP_CDK_DISCOVERY_TRIGGER_QUEUE_CAPACITY:10}
+    await-termination-seconds: ${CP_CDK_DISCOVERY_TRIGGER_AWAIT_TERMINATION_SECONDS:30}
+
 taskmanager:
   schema:
     enabled=true:

--- a/src/test/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/controllers/DiscoverySchedulerControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cp.cdk.controllers;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -8,6 +9,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import uk.gov.hmcts.cp.cdk.services.DiscoverySchedulerConfigurationService;
+import uk.gov.hmcts.cp.cdk.services.DiscoveryTriggerService;
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
 import uk.gov.hmcts.cp.openapi.model.cdk.DiscoverySchedulerConfigurationRequest;
 import uk.gov.hmcts.cp.openapi.model.cdk.UpsertDiscoverySchedulerConfiguration200Response;
 
@@ -24,9 +27,15 @@ class DiscoverySchedulerControllerTest {
 
     private static final MediaType VND =
             MediaType.valueOf("application/vnd.casedocumentknowledge-service.discovery-scheduler-configuration+json");
+    private static final MediaType VND_TRIGGER =
+            MediaType.valueOf("application/vnd.casedocumentknowledge-service.discovery-scheduler-trigger+json");
 
     private MockMvc mvc(final DiscoverySchedulerConfigurationService service) {
-        return MockMvcBuilders.standaloneSetup(new DiscoverySchedulerController(service)).build();
+        return mvc(service, mock(DiscoveryTriggerService.class));
+    }
+
+    private MockMvc mvc(final DiscoverySchedulerConfigurationService service, final DiscoveryTriggerService triggerService) {
+        return MockMvcBuilders.standaloneSetup(new DiscoverySchedulerController(service, triggerService)).build();
     }
 
     @Test
@@ -125,5 +134,27 @@ class DiscoverySchedulerControllerTest {
                         .contentType(VND).accept(VND)
                         .content(body))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /discovery-scheduler/trigger returns 202 with vendor content type and delegates once")
+    void triggerDiscovery_returns_202_and_delegates_once() throws Exception {
+        final DiscoveryTriggerService triggerService = mock(DiscoveryTriggerService.class);
+        final MockMvc mvc = mvc(mock(DiscoverySchedulerConfigurationService.class), triggerService);
+
+        final String body = """
+                {
+                  "discoveryOperation": "INTRADAY"
+                }
+                """;
+
+        mvc.perform(post("/discovery-scheduler/trigger")
+                        .contentType(VND_TRIGGER).accept(VND_TRIGGER)
+                        .content(body))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.discoveryOperation").value("INTRADAY"))
+                .andExpect(jsonPath("$.message").value("Discovery run dispatched."));
+
+        verify(triggerService).trigger(eq(DiscoveryOperation.INTRADAY));
     }
 }

--- a/src/test/java/uk/gov/hmcts/cp/cdk/controllers/GlobalExceptionHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/controllers/GlobalExceptionHandlerTest.java
@@ -144,6 +144,21 @@ class GlobalExceptionHandlerTest {
         assertEquals("Unexpected error", res.getBody().getMessage());
     }
 
+    @Test
+    void onMethodNotSupported_shouldReturn405() throws Exception {
+        when(span.context().traceId()).thenReturn("mmm");
+
+        final org.springframework.web.HttpRequestMethodNotSupportedException ex =
+                new org.springframework.web.HttpRequestMethodNotSupportedException("GET", List.of("POST"));
+
+        final GlobalExceptionHandler handler = new GlobalExceptionHandler(tracer);
+        final ResponseEntity<ErrorResponse> res = handler.onMethodNotSupported(ex);
+
+        assertEquals(HttpStatus.METHOD_NOT_ALLOWED, res.getStatusCode());
+        assertEquals("405", res.getBody().getError());
+        assertEquals("mmm", res.getBody().getTraceId());
+    }
+
     @MockitoSettings(strictness = Strictness.LENIENT)
     @Test
     void traceId_shouldReturnNull_ifTracerThrows() {

--- a/src/test/java/uk/gov/hmcts/cp/cdk/controllers/accesscontrol/CdksAclRulesTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/controllers/accesscontrol/CdksAclRulesTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.cp.cdk.controllers.accesscontrol;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+
+/**
+ * Static check of AC-011: the new trigger rule must have exactly one group-membership
+ * condition -- no hasPermission fallback, no or -- matching discovery-scheduler-configuration's
+ * shape. Behavioural corroboration is DiscoverySchedulerTriggerAclHttpLiveTest (S2.1/S2.2).
+ */
+class CdksAclRulesTest {
+
+    private static final String TRIGGER_ACTION = "casedocumentknowledge-service.discovery-scheduler-trigger";
+    private static final String CONFIGURATION_ACTION = "casedocumentknowledge-service.discovery-scheduler-configuration";
+    private static final Pattern RULE_BLOCK_PATTERN = Pattern.compile("rule\\s+\"([^\"]+)\"\\s*(.*?)\\nend", Pattern.DOTALL);
+
+    private String drlSource() throws IOException {
+        try (InputStream in = new ClassPathResource("acl/cdks-rules.drl").getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private String ruleBlockContaining(final String drl, final String actionName) {
+        final Matcher matcher = RULE_BLOCK_PATTERN.matcher(drl);
+        final List<String> matches = new ArrayList<>();
+        while (matcher.find()) {
+            if (matcher.group(2).contains("\"" + actionName + "\"")) {
+                matches.add(matcher.group(2));
+            }
+        }
+        assertThat(matches)
+                .as("exactly one rule block should target action '%s'", actionName)
+                .hasSize(1);
+        return matches.get(0);
+    }
+
+    @Test
+    void triggerRule_hasExactlyOneGroupMembershipEvalCondition() throws IOException {
+        final String block = ruleBlockContaining(drlSource(), TRIGGER_ACTION);
+
+        final long evalCount = block.lines().filter(line -> line.trim().startsWith("eval(")).count();
+        assertThat(evalCount).as("rule must have exactly one eval(...) condition").isEqualTo(1);
+        assertThat(block).contains("isMemberOfAnyOfTheSuppliedGroups($a, \"System Users\")");
+    }
+
+    @Test
+    void triggerRule_hasNoHasPermissionFallback() throws IOException {
+        assertThat(ruleBlockContaining(drlSource(), TRIGGER_ACTION)).doesNotContain("hasPermission");
+    }
+
+    @Test
+    void triggerRule_hasNoOrConnective() throws IOException {
+        assertThat(ruleBlockContaining(drlSource(), TRIGGER_ACTION)).doesNotContainPattern("\\)\\s*or\\s*\\n");
+    }
+
+    @Test
+    void triggerRule_isStructurallyIdenticalToConfigurationRule_onceActionNameSubstituted() throws IOException {
+        final String drl = drlSource();
+        final String triggerBlock = ruleBlockContaining(drl, TRIGGER_ACTION);
+        final String configurationBlock = ruleBlockContaining(drl, CONFIGURATION_ACTION);
+
+        final String normalisedTrigger = triggerBlock.replace(TRIGGER_ACTION, CONFIGURATION_ACTION);
+
+        assertThat(normalisedTrigger.trim()).isEqualTo(configurationBlock.trim());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerServiceTest.java
@@ -1,0 +1,64 @@
+package uk.gov.hmcts.cp.cdk.services;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.task.TaskExecutor;
+
+@DisplayName("DiscoveryTriggerService tests (Story 3, DD-43062)")
+class DiscoveryTriggerServiceTest {
+
+    private final DiscoveryService discoveryService = mock(DiscoveryService.class);
+    private final TaskExecutor discoveryTriggerExecutor = mock(TaskExecutor.class);
+    private final DiscoveryTriggerService service =
+            new DiscoveryTriggerService(discoveryService, discoveryTriggerExecutor);
+
+    @Test
+    @DisplayName("INTRADAY routes to runIntradayDiscovery via the executor, not the calling thread")
+    void trigger_intraday_routesToRunIntradayDiscovery_offCallingThread() {
+        service.trigger(DiscoveryOperation.INTRADAY);
+
+        verify(discoveryService, never()).runIntradayDiscovery();
+        final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(discoveryTriggerExecutor).execute(captor.capture());
+
+        captor.getValue().run();
+        verify(discoveryService, times(1)).runIntradayDiscovery();
+        verify(discoveryService, never()).runNightlyDiscovery();
+    }
+
+    @Test
+    @DisplayName("NIGHTLY routes to runNightlyDiscovery via the executor, not the calling thread")
+    void trigger_nightly_routesToRunNightlyDiscovery_offCallingThread() {
+        service.trigger(DiscoveryOperation.NIGHTLY);
+
+        final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(discoveryTriggerExecutor).execute(captor.capture());
+
+        captor.getValue().run();
+        verify(discoveryService, times(1)).runNightlyDiscovery();
+        verify(discoveryService, never()).runIntradayDiscovery();
+    }
+
+    @Test
+    @DisplayName("an exception escaping the delegated run is caught and logged, not rethrown (AC-022)")
+    void trigger_delegateThrows_isCaughtNotRethrown() {
+        doThrow(new RuntimeException("boom")).when(discoveryService).runIntradayDiscovery();
+
+        service.trigger(DiscoveryOperation.INTRADAY);
+
+        final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(discoveryTriggerExecutor).execute(captor.capture());
+
+        assertThatCode(() -> captor.getValue().run()).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
 What

  Implements Story 2 (DD-43061) and Story 3 (DD-43062) of the manual discovery scheduler trigger epic (DD-43036): a System-Users-only ACL rule plus the real POST /discovery-scheduler/trigger endpoint that
  fire-and-forget dispatches an on-demand INTRADAY/NIGHTLY discovery run.

  Why

  Ops/support need a way to force a missed or extra discovery run without waiting for its cron or blocking on completion — restricted to trusted System User callers only, with no "AI search" permission fallback.

 Changes
  
  ACL (Story 2, DD-43061)
  - Added casedocumentknowledge-service.discovery-scheduler-trigger Drools rule (acl/cdks-rules.drl) — System-Users-group-only, no hasPermission fallback, structurally identical to the existing
  discovery-scheduler-configuration rule. Signed off by rbac-auditor.
  - New CdksAclRulesTest (static rule-shape check) and DiscoverySchedulerTriggerAclHttpLiveTest (IT: authorised/denied/missing-header scenarios).
  - Added UtilHttp.newClientWithoutDefaultUser() test-support helper for sending a request with no CJSCPPUID header.

  Trigger endpoint (Story 3, DD-43062)
  - New DiscoveryTriggerService: routes DiscoveryOperation.INTRADAY/NIGHTLY to the existing, unchanged DiscoveryService.runIntradayDiscovery()/runNightlyDiscovery() via a dedicated bounded executor;
  fire-and-forget, escaping exceptions caught and logged, not rethrown.
  - New DiscoveryTriggerConfig/DiscoveryTriggerProperties: 1-thread executor bean, configurable queue capacity/await-termination (cdk.discovery-trigger.* in application-cdk.yml).
  - DiscoverySchedulerController.triggerDiscovery(...) returns 202 Accepted with the vendor content type, echoing discoveryOperation, a fixed message, and the request's correlationId (read from MDC — no new
  plumbing needed).
  - New DiscoveryTriggerServiceTest (unit), extended DiscoverySchedulerControllerTest, new DiscoverySchedulerTriggerHttpLiveTest (IT: dispatch, non-blocking, wrong method, validation errors, audit event).


