### PR TITLE
[DD-43083] Persist RAG document-ingestion reference — pipeline docs (Stages 1–4)

### DIFF
--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/00-input-brief.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/00-input-brief.md
@@ -1,0 +1,68 @@
+# 00 — Input Brief
+
+> Raw, unstructured input as given by the requester. Jira ticket: **DD-43083**
+> (https://tools.hmcts.net/jira/browse/DD-43083).
+
+## Brief (verbatim, lightly reformatted from conversation)
+
+As per DD-43083: we need to persist the RAG transaction id for **document ingestion** in the
+`case_documents` table. We already store document reference, blob link, etc., but it would be
+better to also store the RAG transaction id for document ingestion. We recently implemented a RAG
+transaction id for **answer generation** (DD-43084) — use a similarly meaningful column name here,
+something in the spirit of `doc_ingestion_tran_id`.
+
+Requested sequence: produce the Requirements stage document first, with the requirement broken
+down into sub-stories, following the HMCTS SDLC orchestrator plugin pipeline. The requester will
+then review the Design stage with their own designers before stories are formally created and
+implementation begins. A Test Specs step must remain part of the plan.
+
+## Source
+
+Jira ticket DD-43083 (title/description not fetched — no Jira/Atlassian MCP tool access in this
+session; the brief above is the requester's own restatement of the ticket in conversation). The
+ticket's literal text should be verified before this requirement is taken to the Story stage — see
+Open Question OQ-001 in `01-requirements.md`.
+
+## Ground truth gathered from the codebase before drafting requirements
+
+- **This is the ingestion-side sibling of DD-43084** (`../DD-43084-persist-rag-transaction-id/`),
+  which added `rag_transaction_id UUID NULL` to the four answer tables. The same class of gap
+  exists one step earlier in the pipeline, on document ingestion rather than answer generation.
+- `RetrieveMaterialAndUploadTask` (`jobmanager/caseflow/RetrieveMaterialAndUploadTask.java`) calls
+  `DocumentIngestionInitiationApi.initiateDocumentUpload(...)` (RAG service, via
+  `ApimDocumentIngestionClient`) and gets back a `FileStorageLocationReturnedSuccessfully` with
+  `storageUrl` and `documentReference`. `documentReference` is the RAG-issued correlation id for
+  this ingestion transaction — the direct ingestion-side analogue of the answer flow's
+  `transactionId`.
+- That task forwards `documentReference` only via Task Manager job data
+  (`JobManagerKeys.CTX_DOC_REFERENCE_KEY = "documentReference"`) to the next task,
+  `CheckIngestionStatusForAllDefendantsTask`, which uses it solely to poll
+  `DocumentIngestionStatusApi.documentStatusByReference(documentReference)` and as a log
+  correlation value. Once ingestion status resolves (`INGESTION_SUCCESS` or a failure status), the
+  value is dropped — never written onto the `CaseDocument` row it correlates to.
+- `case_documents` (`V1001__case_documents_ai_schema.sql`, entity `domain/CaseDocument.java`) has
+  no column for this today. The row for a given `doc_id` is created earlier in the flow (before
+  `RetrieveMaterialAndUploadTask` runs) and is next updated by
+  `RetrieveMaterialAndUploadTask.saveDocumentUploaded(...)` (sets `docName`, `blobUri`,
+  `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase=UPLOADED`) — this is the natural place
+  to also persist the new column, since `documentReference` becomes known in the same method
+  (`initiateDocumentUpload(...)`, line ~116) just before that save call.
+- **Type note (differs from the DD-43084 precedent):** the answer-flow `transactionId` is parsed
+  and stored as `UUID` (`TaskUtils.parseUuidOrNull`) end-to-end. `documentReference` here is typed
+  `String` throughout the generated RAG API model
+  (`FileStorageLocationReturnedSuccessfully.documentReference`,
+  `DocumentIngestionStatusApi.documentStatusByReference(String)`) and is never parsed/validated as
+  a UUID anywhere in this codebase — it is treated as an opaque correlation string. The new
+  column's SQL type is therefore an open design decision (`TEXT` vs `UUID`), not a given — see
+  OQ-002 / ADR candidate in Design stage.
+- This is the same category of problem the CDKS hard rule "do not drop RAG response fields" names
+  for `doc_id`/`llm_input` (`.claude/context/cdks-context.md`) and that DD-43084 already fixed on
+  the answer side — `documentReference` is RAG-provenance data being silently discarded before the
+  last persistence step on the ingestion side.
+- Next available Flyway version is `V1013` (`V1012` was consumed by DD-43084's
+  `rag_transaction_id` migration on the answer tables).
+- No controller, mapper, or API response currently exposes any `CaseDocument` field externally
+  (`grep` found only `RetrieveMaterialAndUploadTask`, `services/DocumentService`,
+  `services/IdpcAvailabilityService` as consumers of the entity, and no `CaseDocumentMapper`
+  exists) — so, mirroring DD-43084/ADR-002, this looks like a persist-only change with no API
+  surface impact, pending confirmation at Design stage.

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/01-requirements.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/01-requirements.md
@@ -96,17 +96,16 @@ version; the answer-side `rag_transaction_id` columns delivered by DD-43084.
 
 ## Non-Functional Requirements
 
+Trimmed to the NFRs that carry ticket-specific decision content. Migration governance, PMD/JaCoCo,
+platform versions, and logging rules are covered once, generically, by CLAUDE.md's hard rules and
+are not repeated here per requirement.
+
 | ID | Category | Requirement |
 |----|----------|-------------|
-| NFR-001 | Data protection | `documentReference` is an opaque, RAG-issued correlation string — not PII, not case content, not a court reference number. Both `RetrieveMaterialAndUploadTask` and `CheckIngestionStatusForAllDefendantsTask` already log it at INFO today, so persisting it introduces no new data-protection exposure. Same reasoning as DD-43084/NFR-001. |
-| NFR-002 | Traceability | After this change, every uploaded document row can be tied back to the exact RAG ingestion transaction that produced it, closing the ingestion-side half of the gap DD-43084 closed on the answer side. |
-| NFR-003 | Migration safety | `ALTER TABLE case_documents ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL 16 — no table rewrite, no lock escalation, no default backfill — regardless of current row count. No existing column, constraint (`cd_blob_uri_not_blank`, `cd_source_not_blank`, `cd_size_nonneg`, `cd_sha256_shape`), index, or the `document_ingestion_phase_enum` type is touched. |
-| NFR-004 | Backward compatibility | No change to any GET response shape or SQL read path. `IdpcAvailabilityService.persistCaseDocument(...)` and `DocumentService` keep compiling and behaving unchanged (new field simply unset). The raw `INSERT INTO case_documents (...)` in `IngestionProcessByCaseHttpLiveTest` continues to work untouched, precisely because the column is nullable. |
-| NFR-005 | Testability | Unit coverage in `RetrieveMaterialAndUploadTaskTest` asserting the persisted entity carries the value; `CheckIngestionStatusForAllDefendantsTaskTest` still green; `integrationTest` coverage asserting the column is populated end-to-end through the existing WireMock stub `wiremock/mappings/document_upload_to_generate_url.json` (which already returns a synthetic UUID-shaped `documentReference`). `gradle integration` passes against the compose stack. |
-| NFR-006 | Migration governance | The new `V1013__*.sql` is routed through the `migration-reviewer` agent per CLAUDE.md's hard rule for any change under `db/migration`. Shipped migrations `V1000`–`V1012` are never edited. |
-| NFR-007 | Code quality | PMD and JaCoCo pass at existing thresholds; no new suppressions. If adding a parameter pushes `saveDocumentUploaded(...)` past a PMD parameter-count rule, pass the `FileStorageLocationReturnedSuccessfully` (or a small local record) rather than suppressing the rule. |
-| NFR-008 | Platform | Java 25 / Spring Boot 4.0.5 / Gradle 9 / PostgreSQL 16 / Flyway 7.x. The existing Spring Data JPA `saveAndFlush` write pattern on `CaseDocument` is preserved — no raw SQL is introduced on this path. |
-| NFR-009 | Logging | JSON-to-stdout logging unchanged; no `System.out`; no document body or case content logged. The existing "Saved CaseDocument …" log line may include the reference (already-permitted data), but no new log statement is required by this change. |
+| NFR-001 | Data protection | `documentReference` is an opaque, RAG-issued correlation string — not PII, not case content, not a court reference number. Both `RetrieveMaterialAndUploadTask` and `CheckIngestionStatusForAllDefendantsTask` already log it at INFO today, so persisting it introduces no new data-protection exposure. |
+| NFR-002 | Migration safety | `ALTER TABLE case_documents ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL 16 — no table rewrite, no lock escalation — regardless of current row count. No existing column, constraint, index, or the `document_ingestion_phase_enum` type is touched. |
+| NFR-003 | Backward compatibility | No change to any GET response shape or SQL read path. `IdpcAvailabilityService.persistCaseDocument(...)` and `DocumentService` keep compiling and behaving unchanged. The raw `INSERT INTO case_documents (...)` in `IngestionProcessByCaseHttpLiveTest` continues to work, precisely because the column is nullable. |
+| NFR-004 | Testability | Unit coverage in `RetrieveMaterialAndUploadTaskTest` / `CheckIngestionStatusForAllDefendantsTaskTest`; `integrationTest` coverage asserting the column is populated end-to-end through the RAG WireMock stub. `gradle integration` passes against the compose stack. |
 
 ---
 
@@ -158,7 +157,7 @@ DD-43084 was split into DD-43104 / DD-43105 / DD-43106.
    its own beyond what Story 2 delivers.*
 4. **Story 4 — Test coverage end-to-end.** Unit assertions on the captured entity plus an
    `integrationTest` assertion that the column is populated from the existing WireMock stub; keep
-   PMD/JaCoCo green. Covers NFR-005, AC-011, AC-012, AC-013.
+   PMD/JaCoCo green. Covers NFR-004, AC-011, AC-012, AC-013.
 
 Explicitly **not** a story in this requirement: any API exposure of the field, a lookup-by-reference
 endpoint, or a backfill job.

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/01-requirements.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/01-requirements.md
@@ -1,0 +1,205 @@
+# Requirements: Persist RAG Document-Ingestion Transaction Id on `case_documents`
+
+> **Stage 1 — Requirements** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43083**
+> Ingestion-side sibling of **DD-43084** (`../DD-43084-persist-rag-transaction-id/`), which added
+> `rag_transaction_id UUID NULL` to the four answer tables. Same class of gap, one step earlier in
+> the pipeline. Column name and SQL type are deliberately left open for the Design stage — see
+> OQ-002 / OQ-003; both are expected to be recorded in
+> `adrs/DD-43083-persist-doc-ingestion-transaction-id.md`.
+
+---
+
+## Context
+
+CDKS ingests a case document asynchronously. `RetrieveMaterialAndUploadTask`
+(`jobmanager/caseflow/`) fetches the material download URL from Progression, calls the RAG
+service's `initiateDocumentUpload(...)` (via `ApimDocumentIngestionClient` →
+`DocumentIngestionInitiationApi`) and receives a `FileStorageLocationReturnedSuccessfully`
+carrying a `storageUrl` and a `documentReference`. `documentReference` is the RAG-issued
+correlation id for that ingestion transaction — the direct ingestion-side analogue of the answer
+flow's `transactionId`. The task then copies the blob, updates the `case_documents` row via
+`saveDocumentUploaded(...)` (`docName`, `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`,
+`ingestionPhase = UPLOADED`, `ingestionPhaseAt`), and forwards `documentReference` **only** through
+Task Manager job data (`JobManagerKeys.CTX_DOC_REFERENCE_KEY = "documentReference"`) to
+`CheckIngestionStatusForAllDefendantsTask`.
+
+That downstream task uses the value solely to poll
+`DocumentIngestionStatusApi.documentStatusByReference(documentReference)` and as a log correlation
+value. Once ingestion resolves (`INGESTION_SUCCESS`, or `INGESTION_FAILED` / `INVALID_METADATA` /
+`FILE_SIZE_OVER_LIMIT`), the value is discarded with the job data. `case_documents` (created in
+`V1001`, entity `domain/CaseDocument.java`) has no column for it, so the ingestion transaction that
+produced a given stored document is unrecoverable after the fact.
+
+This is the same class of problem the CDKS hard rule "do not drop RAG response fields" already
+covers for `doc_id`/`llm_input` (`.claude/context/cdks-context.md`), and that DD-43084 fixed on the
+answer side: RAG-provenance data silently lost at the last step before persistence, undermining the
+traceability CDKS is meant to guarantee for AI-assisted case document handling.
+
+The fix has a natural single write point. `documentReference` becomes known at
+`RetrieveMaterialAndUploadTask` line ~116, a few lines before the `saveDocumentUploaded(...)` call
+at line ~125 that already updates the same row. No new upsert, no second transaction, and no new
+repository method is required.
+
+**Note on source:** this requirement is derived from the requester's own restatement of Jira
+DD-43083 in conversation; the ticket itself was not fetched (no Jira/Atlassian tool access in this
+session — see OQ-001). Treat the FR/AC below as the working scope until confirmed against the
+ticket text.
+
+### Type and naming: what the contract actually says (informs OQ-002 / OQ-003)
+
+Verified against the consumed RAG contract (`api-cp-ai-rag:0.0.15`,
+`openapi/ai-rag-service.openapi.yml`) and the generated model:
+
+- The spec declares `documentReference` as `allOf: [$ref '#/components/schemas/uuid']`, where
+  `uuid` is `type: string` with a UUID **regex pattern** (not `format: uuid`). The status endpoint
+  `/document-upload/{documentReference}` documents a `400 — documentReference is not a valid uuid`.
+  So the value is contractually UUID-shaped.
+- Because the schema uses `pattern` rather than `format: uuid`, the generated Java type is
+  `String`, not `java.util.UUID` (`FileStorageLocationReturnedSuccessfully.getDocumentReference()`,
+  `DocumentIngestionStatusApi.documentStatusByReference(String)`). It carries `@NotNull` and
+  `@Pattern` annotations, but response bodies are not bean-validated on the client path, so nothing
+  in CDKS enforces or parses the shape today — it is handled purely as an opaque string.
+- The answer-side `transactionId` uses the **same** `uuid` schema, and DD-43084 nonetheless stored
+  it as a `UUID` column, parsing via `TaskUtils.parseUuidOrNull`. That precedent argues for `UUID`
+  here; the counter-argument is that `parseUuidOrNull` silently yields `null` on a malformed value,
+  which would discard exactly the provenance data this requirement exists to preserve.
+
+The column's SQL type is therefore a real design decision with evidence on both sides, not a
+given. It must be settled at Design stage with an explicit fallback story — see OQ-003 and AC-014.
+
+---
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR-001 | `RetrieveMaterialAndUploadTask` persists the `documentReference` returned by `initiateDocumentUpload(...)` onto the `case_documents` row for that `doc_id`. |
+| FR-002 | The value is written inside the existing `saveDocumentUploaded(...)` call — the same single `saveAndFlush` that already sets `docName`, `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase = UPLOADED`, `ingestionPhaseAt`. No new write, no second transaction, no new upsert flow, no new `CaseDocumentRepository` method. |
+| FR-003 | `case_documents` gains **one** new nullable column for this value via a single append-only Flyway migration, `V1013` (`V1012` is consumed by DD-43084). Working name `doc_ingestion_tran_id`; final name (OQ-002) and SQL type (OQ-003) are Design-stage decisions and must be recorded in the ADR before implementation. |
+| FR-004 | The `CaseDocument` JPA entity gains a mapped field for the new column, so the entity accurately reflects its table. This is the write path (unlike DD-43084, where the answer tables are written via raw `NamedParameterJdbcTemplate` SQL and the entity change was read-side only). |
+| FR-005 | The value is written once, at the `UPLOADED` transition, and is never cleared or overwritten by later phase transitions. `CheckIngestionStatusForAllDefendantsTask.updateIngestionPhase(...)` moves the row to `INGESTED` / `FAILED` / `EXCEEDED_FILE_SIZE_LIMIT` via the same entity — the new field must survive those saves unchanged. |
+| FR-006 | Existing job-data threading is unchanged: `RetrieveMaterialAndUploadTask` still adds `CTX_DOC_REFERENCE_KEY` to the job data and `CheckIngestionStatusForAllDefendantsTask` still reads it from there to poll. This requirement adds a persistence sink; it does not replace the task-to-task hand-off. |
+| FR-007 | No new failure mode. If RAG returns a null or blank `documentReference`, the new column is left `NULL` and the surrounding flow behaves exactly as it does today (a null value already fails inside the existing `try` block, because the job-data `add(...)` rejects a null, and the task retries). The added persistence must not itself throw, and must not turn a previously-succeeding upload into a failure. |
+| FR-008 | No backfill. Rows created by `IdpcAvailabilityService.persistCaseDocument(...)` (phase `WAITING_FOR_UPLOAD`), rows whose upload never reached `saveDocumentUploaded(...)`, and every row written before this migration all show the new column `IS NULL`. |
+| FR-009 | No API/contract change — persistence only, mirroring DD-43084/ADR-002. No controller, mapper, or response DTO exposes any `CaseDocument` field today (only `RetrieveMaterialAndUploadTask`, `services/DocumentService`, `services/IdpcAvailabilityService` and `CaseDocumentRepository` consume the entity; there is no `CaseDocumentMapper`). `version.cdk` is not bumped and `api-cp-crime-caseadmin-case-document-knowledge` is untouched. |
+| FR-010 | No index is added on the new column. There is no query-by-reference read path in CDKS today, and the three existing `case_documents` indexes (`idx_cd_case_uploaded_desc`, `idx_cd_case_phase`, `idx_cd_phase`) are unaffected. See OQ-005 if a support lookup need is asserted. |
+
+**Out of scope:** exposing the value over any API or adding a lookup-by-reference endpoint;
+backfilling historic rows; refactoring `CheckIngestionStatusForAllDefendantsTask` to read the
+reference from `case_documents` instead of job data (OQ-006); storing the `storageUrl` query-string
+/ SAS portion of the upload response; changing ingestion retry, phase-transition, or failure
+semantics; any change to `ApimDocumentIngestionClient`, `RagClientsConfig`, or the RAG contract
+version; the answer-side `rag_transaction_id` columns delivered by DD-43084.
+
+---
+
+## Non-Functional Requirements
+
+| ID | Category | Requirement |
+|----|----------|-------------|
+| NFR-001 | Data protection | `documentReference` is an opaque, RAG-issued correlation string — not PII, not case content, not a court reference number. Both `RetrieveMaterialAndUploadTask` and `CheckIngestionStatusForAllDefendantsTask` already log it at INFO today, so persisting it introduces no new data-protection exposure. Same reasoning as DD-43084/NFR-001. |
+| NFR-002 | Traceability | After this change, every uploaded document row can be tied back to the exact RAG ingestion transaction that produced it, closing the ingestion-side half of the gap DD-43084 closed on the answer side. |
+| NFR-003 | Migration safety | `ALTER TABLE case_documents ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL 16 — no table rewrite, no lock escalation, no default backfill — regardless of current row count. No existing column, constraint (`cd_blob_uri_not_blank`, `cd_source_not_blank`, `cd_size_nonneg`, `cd_sha256_shape`), index, or the `document_ingestion_phase_enum` type is touched. |
+| NFR-004 | Backward compatibility | No change to any GET response shape or SQL read path. `IdpcAvailabilityService.persistCaseDocument(...)` and `DocumentService` keep compiling and behaving unchanged (new field simply unset). The raw `INSERT INTO case_documents (...)` in `IngestionProcessByCaseHttpLiveTest` continues to work untouched, precisely because the column is nullable. |
+| NFR-005 | Testability | Unit coverage in `RetrieveMaterialAndUploadTaskTest` asserting the persisted entity carries the value; `CheckIngestionStatusForAllDefendantsTaskTest` still green; `integrationTest` coverage asserting the column is populated end-to-end through the existing WireMock stub `wiremock/mappings/document_upload_to_generate_url.json` (which already returns a synthetic UUID-shaped `documentReference`). `gradle integration` passes against the compose stack. |
+| NFR-006 | Migration governance | The new `V1013__*.sql` is routed through the `migration-reviewer` agent per CLAUDE.md's hard rule for any change under `db/migration`. Shipped migrations `V1000`–`V1012` are never edited. |
+| NFR-007 | Code quality | PMD and JaCoCo pass at existing thresholds; no new suppressions. If adding a parameter pushes `saveDocumentUploaded(...)` past a PMD parameter-count rule, pass the `FileStorageLocationReturnedSuccessfully` (or a small local record) rather than suppressing the rule. |
+| NFR-008 | Platform | Java 25 / Spring Boot 4.0.5 / Gradle 9 / PostgreSQL 16 / Flyway 7.x. The existing Spring Data JPA `saveAndFlush` write pattern on `CaseDocument` is preserved — no raw SQL is introduced on this path. |
+| NFR-009 | Logging | JSON-to-stdout logging unchanged; no `System.out`; no document body or case content logged. The existing "Saved CaseDocument …" log line may include the reference (already-permitted data), but no new log statement is required by this change. |
+
+---
+
+## Acceptance Criteria
+
+**Persistence**
+- AC-001: Given a `RETRIEVE_MATERIAL_AND_UPLOAD` execution where `initiateDocumentUpload(...)` returns a `documentReference`, when the task completes successfully, then the `case_documents` row for that `doc_id` holds that value in the new column — preserved exactly as received, with no truncation, trimming, case-folding, or re-formatting (subject only to the type decision in OQ-003).
+- AC-002: The value is written in the **same** `saveAndFlush` as `docName`, `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase = UPLOADED` — verified by a unit test that captures the `CaseDocument` passed to `CaseDocumentRepository.saveAndFlush(...)` and asserts a single invocation carrying all of those fields plus the new one.
+- AC-003: Given a row with the value persisted, when `CheckIngestionStatusForAllDefendantsTask` subsequently transitions the phase to `INGESTED`, `FAILED`, or `EXCEEDED_FILE_SIZE_LIMIT`, then the new column still holds the original value — not nulled, not changed.
+
+**Null / absent handling**
+- AC-004: Given RAG returns a null or blank `documentReference`, when the task runs, then the new persistence code throws no exception of its own and the task's existing outcome (retry via `ExecutionStatus.INPROGRESS`) is unchanged from current behaviour; any row written shows the new column `IS NULL`.
+- AC-005: A row created by `IdpcAvailabilityService.persistCaseDocument(...)` in phase `WAITING_FOR_UPLOAD` shows the new column `IS NULL` until upload initiation completes for that document.
+- AC-006: Rows that predate the `V1013` migration show the new column `IS NULL` — no error, no backfill attempted.
+
+**No API surface change**
+- AC-007: No controller, response DTO, or mapper changes; `version.cdk` is unchanged; `IngestionProcessByCaseHttpLiveTest` (and every other existing `*HttpLiveTest`) passes with its assertions unmodified.
+
+**Migration**
+- AC-008: `V1013__*.sql` adds exactly one nullable column to `case_documents`, plus a `COMMENT ON COLUMN` explaining the field and its nullability — no rename, no drop, no `NOT NULL`, no default, no data rewrite, no change to any other table — and is reviewed by `migration-reviewer` before merge.
+- AC-009: Flyway migrates cleanly both on a fresh database and on a database already at `V1012` with existing `case_documents` rows; the `gradle integration` compose stack starts and the app reaches readiness.
+
+**Tests and quality**
+- AC-010: `RetrieveMaterialAndUploadTaskTest` and `CheckIngestionStatusForAllDefendantsTaskTest` compile and pass with any updated signatures.
+- AC-011: An integration test asserts the new column is populated with the stubbed `documentReference` from `document_upload_to_generate_url.json` after the ingestion flow reaches `UPLOADED`, i.e. the value survives end-to-end and not just in a mocked unit.
+- AC-012: `gradle clean build` (including `integration`) passes; PMD and JaCoCo are green at existing, unmodified thresholds; CodeQL and the secrets scanner are clean.
+- AC-013: The diff introduces no PII, case content, court reference number, or `CJSCPPUID` into the migration, tests, or fixtures; WireMock/Azurite fixture values remain synthetic.
+- AC-014: Whichever SQL type Design settles on (OQ-003), a `documentReference` that does not match the RAG contract's UUID pattern must neither (a) be silently discarded nor (b) fail the ingestion flow. The chosen behaviour is recorded in the ADR and covered by an explicit test.
+
+---
+
+## Candidate Sub-Stories (preview for Stage 3)
+
+Indicative breakdown for the User Story stage to formalise; each will need its own Jira sub-ticket
+before Test Specs (per the CLAUDE.md rule that every story has a linked ticket), mirroring how
+DD-43084 was split into DD-43104 / DD-43105 / DD-43106.
+
+1. **Story 1 — Schema: add the nullable column to `case_documents`.** One append-only Flyway
+   migration `V1013__*.sql` adding the agreed column (name per OQ-002, type per OQ-003) with a
+   column comment; routed through `migration-reviewer`. Covers FR-003, AC-008, AC-009.
+2. **Story 2 — Entity and persistence: thread the value through and store it.** Add the mapped
+   field to `CaseDocument`; pass `documentReference` from `initiateDocumentUpload(...)` into
+   `saveDocumentUploaded(...)` in `RetrieveMaterialAndUploadTask`; single write, null-safe. Covers
+   FR-001, FR-002, FR-004, FR-007, FR-008, AC-001, AC-002, AC-004, AC-005, AC-006, AC-014.
+3. **Story 3 — No regression on the ingestion status path.** Confirm job-data threading is
+   untouched and that the value survives every later phase transition performed by
+   `CheckIngestionStatusForAllDefendantsTask`. Covers FR-005, FR-006, AC-003, AC-010. *May be
+   folded into Story 2 if reviewers prefer — it is assertion-only, with no production change of
+   its own beyond what Story 2 delivers.*
+4. **Story 4 — Test coverage end-to-end.** Unit assertions on the captured entity plus an
+   `integrationTest` assertion that the column is populated from the existing WireMock stub; keep
+   PMD/JaCoCo green. Covers NFR-005, AC-011, AC-012, AC-013.
+
+Explicitly **not** a story in this requirement: any API exposure of the field, a lookup-by-reference
+endpoint, or a backfill job.
+
+---
+
+## Open Questions
+
+- **OQ-001:** Jira ticket DD-43083 itself was not fetched in this session (no Jira/Atlassian tool
+  access) — confirm the ticket's literal text matches this restated scope (persist-only, single
+  column on `case_documents`, no API exposure) before moving past the Story stage. If the ticket
+  asks for API exposure or a support-facing lookup, the FR-009 / FR-010 boundary needs revisiting
+  first. — Owner: requester · Due: before Stage 3.
+- **OQ-002 (column name — designer call):** the brief's working name is `doc_ingestion_tran_id`,
+  echoing the requester's naming direction. Two counter-considerations for the Design review:
+  (a) DD-43084 established `rag_transaction_id` as the convention for RAG correlation ids in this
+  schema, so a `rag_`-prefixed name (e.g. `rag_ingestion_transaction_id`) would keep the two
+  siblings visually consistent; (b) the upstream contract calls this field `documentReference`, not
+  a transaction id at all, so `*_tran_id` diverges from the source vocabulary and a name like
+  `rag_document_reference` would be the most literal. Settle at Design stage with the requester's
+  designers and record the choice in the ADR. — Owner: requester's design reviewers · Due: Stage 2.
+- **OQ-003 (SQL type — `TEXT` vs `UUID`):** evidence both ways, per the Context section above. For
+  `UUID`: the RAG contract constrains the field to a UUID pattern, the status endpoint 400s on a
+  non-UUID, and DD-43084 stored the same-schema `transactionId` as `UUID`. For `TEXT`: the
+  generated Java type is `String`, nothing in CDKS parses or validates it, and `parseUuidOrNull`
+  would silently null a malformed value — losing the exact provenance this ticket exists to keep.
+  If `UUID` is chosen, the fallback must be specified (reject-and-retry? log-and-store-null?
+  store in a shadow `TEXT` column?) and tested per AC-014. — Owner: requester's design reviewers ·
+  Due: Stage 2, ADR required.
+- **OQ-004:** Confirm no external consumer (BI/reporting job, data export, another service reading
+  the CDKS database directly) needs advance notice of a new nullable column on `case_documents`.
+  Nothing in this repo reads it outside `CaseDocumentRepository`, but `case_documents` may be
+  queried from outside this codebase. — Owner: TBD · Due: before merge.
+- **OQ-005:** Is there a support/ops need to look a document up *by* its ingestion reference? If
+  so, FR-010 (no index) should be revisited — an index would be a separate, additive migration.
+  No such read path exists in CDKS today. — Owner: TBD · Due: Stage 2.
+- **OQ-006:** Should `CheckIngestionStatusForAllDefendantsTask` eventually read the reference from
+  the persisted row rather than job data (which would let a replayed or resumed job recover it)?
+  Deliberately out of scope here, but worth confirming it is not the ticket's actual driver — if it
+  is, the scope grows beyond persistence. — Owner: requester · Due: before Stage 3.
+- **OQ-007:** Confirm the new column simply inherits the retention/purge policy of the
+  `case_documents` row it sits on, and carries no separate audit or retention obligation of its
+  own. Assumed yes (it is a correlation id, not case data), but state it explicitly for the
+  data-protection review. — Owner: TBD · Due: before merge.

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/02-design.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/02-design.md
@@ -38,7 +38,7 @@ COMMENT ON COLUMN case_documents.rag_document_reference IS
 
 - Plain `TEXT NULL` — no `NOT NULL`, no `DEFAULT`, no `CHECK`, no index. `ADD COLUMN` of a
   nullable column with no default is metadata-only on PostgreSQL 16 (no table rewrite, no lock
-  escalation), matching NFR-003.
+  escalation), matching NFR-002.
 - **No `CHECK` constraint deliberately.** The table does have a shape check on a comparable opaque
   string — `cd_sha256_shape CHECK (sha256_hex IS NULL OR sha256_hex ~ '^[0-9a-fA-F]{64}$')`
   (`V1001__case_documents_ai_schema.sql`) — and it would be easy to add the RAG UUID pattern here
@@ -55,7 +55,7 @@ COMMENT ON COLUMN case_documents.rag_document_reference IS
   (`fk_cqs_doc`, `fk_cllda_doc`, `fk_def_doc` all reference `case_documents.doc_id`) or the
   `document_ingestion_phase_enum` type is touched.
 - Route through `migration-reviewer` per CLAUDE.md's hard rule for any `db/migration` change
-  (AC-008, NFR-006). Shipped `V1000`–`V1012` are not edited.
+  (AC-008). Shipped `V1000`–`V1012` are not edited.
 
 ### 2. Files touched
 
@@ -168,8 +168,8 @@ private void saveDocumentUploaded(final CaseDocument doc, final String blobName,
   file (line 3); it is null-safe, so no separate null guard is needed.
 - **Fifth parameter is fine for PMD.** `.github/pmd-ruleset.xml` includes only the `bestpractices`,
   `codestyle`, `errorprone`, `performance` and `security` categories — the `design` category (which
-  owns `ExcessiveParameterList`, default threshold 10) is not enabled, so NFR-007's contingency
-  does not bite. An explicit `String documentReference` parameter is preferred over passing
+  owns `ExcessiveParameterList`, default threshold 10) is not enabled, so PMD does not object to
+  the fifth parameter. An explicit `String documentReference` parameter is preferred over passing
   `FileStorageLocationReturnedSuccessfully` into the persistence helper, which would couple a
   private DB-write method to a generated RAG API model. If this parameter list grows again, the
   right refactor is a small local record (e.g. `UploadedBlob(blobName, blobUrl, sizeBytes)`), not a
@@ -246,7 +246,7 @@ No `TaskUtils` test is needed — nothing is added there (contrast DD-43084, whi
 `buildAnswerParams`).
 
 **Integration (`src/integrationTest/`)** — asserts the value survives end-to-end and not just in a
-mocked unit (AC-011, NFR-005).
+mocked unit (AC-011, NFR-004).
 
 Recommended shape: a dedicated live test mirroring DD-43084's
 `jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` — seed a `jobs` row
@@ -282,7 +282,7 @@ Also in scope for the IT pass, both assertion-only:
 - `IngestionProcessByCaseHttpLiveTest`, `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`,
   `DocumentHttpLiveTest` run **unmodified and green** — no response body gains a field (AC-007), and
   the raw `INSERT INTO case_documents (...)` in `IngestionProcessByCaseHttpLiveTest` keeps working
-  precisely because the column is nullable (NFR-004).
+  precisely because the column is nullable (NFR-003).
 - App startup succeeds against a database migrated from `V1012` with pre-existing
   `case_documents` rows — which is also the live proof that `ddl-auto: validate` accepts the new
   `String` → `TEXT` mapping (AC-006, AC-009).

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/02-design.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/02-design.md
@@ -1,0 +1,296 @@
+# Design: Persist the RAG Document-Ingestion Reference on `case_documents`
+
+> **Stage 2 — Architecture & Design** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43083** · Requirements: [`01-requirements.md`](./01-requirements.md) · ADRs: [`adrs/DD-43083-persist-doc-ingestion-transaction-id.md`](../adrs/DD-43083-persist-doc-ingestion-transaction-id.md)
+> Add `rag_document_reference TEXT NULL` to `case_documents` (`V1013`); persist the
+> `documentReference` that `RetrieveMaterialAndUploadTask` already receives from
+> `initiateDocumentUpload(...)` inside the existing `saveDocumentUploaded(...)` write.
+> No API/contract change, no new endpoint, no ACL change, no new repository method, no index.
+>
+> **Two Stage 1 open questions are resolved here and recorded as ADRs — both Accepted, confirmed
+> by the requester after design review on 2026-08-11:**
+> **OQ-002 (column name) → ADR-001: `rag_document_reference`** (not `doc_ingestion_tran_id`).
+> **OQ-003 (SQL type) → ADR-002: `TEXT`, stored verbatim, no parse, no CHECK** (diverging from
+> DD-43084's `UUID` for reasons set out in the ADR). §1–§4 below are locked design, not proposals.
+
+---
+
+## Detailed Design
+
+### 1. Migration (this repo — no external contract dependency)
+
+**File:** `src/main/resources/db/migration/V1013__add_rag_document_reference_to_case_documents.sql`
+(next version after `V1012`, which DD-43084 consumed).
+
+```sql
+-- ----------------------------------------------------------------------------
+-- Persist the RAG-issued documentReference for the document-ingestion upload
+-- transaction that produced this row (ingestion-side analogue of the answer
+-- tables' rag_transaction_id, added in V1012).
+-- Nullable, additive: rows written before this migration keep NULL, no backfill.
+-- Stored verbatim as TEXT — no parse, no shape CHECK — see ADR-002 (DD-43083).
+-- ----------------------------------------------------------------------------
+ALTER TABLE case_documents
+    ADD COLUMN IF NOT EXISTS rag_document_reference TEXT NULL;
+COMMENT ON COLUMN case_documents.rag_document_reference IS
+'RAG-issued documentReference returned by POST /document-upload — the ingestion-transaction correlation id for this document (ingestion-side analogue of answers.rag_transaction_id). Stored verbatim as received; nullable — NULL for rows in WAITING_FOR_UPLOAD, for uploads that never reached the UPLOADED transition, and for rows written before this column existed (not backfilled).';
+```
+
+- Plain `TEXT NULL` — no `NOT NULL`, no `DEFAULT`, no `CHECK`, no index. `ADD COLUMN` of a
+  nullable column with no default is metadata-only on PostgreSQL 16 (no table rewrite, no lock
+  escalation), matching NFR-003.
+- **No `CHECK` constraint deliberately.** The table does have a shape check on a comparable opaque
+  string — `cd_sha256_shape CHECK (sha256_hex IS NULL OR sha256_hex ~ '^[0-9a-fA-F]{64}$')`
+  (`V1001__case_documents_ai_schema.sql`) — and it would be easy to add the RAG UUID pattern here
+  by analogy. It is rejected: a failing CHECK raises on `saveAndFlush`, which would turn a
+  malformed-but-otherwise-successful upload into a task failure and violate FR-007 ("must not turn
+  a previously-succeeding upload into a failure"). Shape validation is the RAG contract's
+  responsibility, not CDKS's storage layer's — see ADR-002.
+- **No index** (FR-010). No lookup-by-reference read path exists in CDKS; the three existing
+  indexes (`idx_cd_case_uploaded_desc`, `idx_cd_case_phase`, `idx_cd_phase`) are untouched. A
+  btree index on a `TEXT` column is an independent additive migration later if OQ-005 turns out to
+  have a real ops need.
+- No existing column, constraint (`cd_blob_uri_not_blank`, `cd_source_not_blank`,
+  `cd_size_nonneg`, `cd_sha256_shape`), index, view (`v_case_ingestion_status`), FK
+  (`fk_cqs_doc`, `fk_cllda_doc`, `fk_def_doc` all reference `case_documents.doc_id`) or the
+  `document_ingestion_phase_enum` type is touched.
+- Route through `migration-reviewer` per CLAUDE.md's hard rule for any `db/migration` change
+  (AC-008, NFR-006). Shipped `V1000`–`V1012` are not edited.
+
+### 2. Files touched
+
+| File | Change |
+|---|---|
+| `db/migration/V1013__add_rag_document_reference_to_case_documents.sql` *(new)* | Adds one nullable `TEXT` column + `COMMENT ON COLUMN`. |
+| `domain/CaseDocument.java` | New `@Column(name = "rag_document_reference") private String ragDocumentReference;`. |
+| `jobmanager/caseflow/RetrieveMaterialAndUploadTask.java` | Extract `documentReference` into a local (line ~116); pass it into `saveDocumentUploaded(...)` (line ~125); set it on the entity in `saveDocumentUploaded(...)` (lines ~227–236). |
+
+**No new constant is required.** The job-data key constant already exists
+(`jobmanager/support/JobManagerKeys.java:7` — `CTX_DOC_REFERENCE_KEY = "documentReference"`) and is
+unchanged; the column name lives only in the entity's `@Column` annotation, matching how every
+other `CaseDocument` column is declared. No `TaskUtils` helper is needed either — unlike DD-43084,
+there is no parse step (ADR-002) and no `MapSqlParameterSource` on this path.
+
+**Not changed:**
+- `repo/CaseDocumentRepository.java` — **confirmed no change needed.** It is a
+  `JpaRepository<CaseDocument, UUID>`; `saveAndFlush(...)` and `findById(...)` are inherited and
+  persist/hydrate whatever the entity maps. Its two `@Query(nativeQuery = true)`
+  `findSupersededDocuments(...)` methods select `distinct(cd.doc_id)` only, so neither is affected
+  by a new column, and `findFirstByCaseIdOrderByUploadedAtDesc` is a derived query over unchanged
+  fields.
+- `jobmanager/caseflow/CheckIngestionStatusForAllDefendantsTask.java` — see §5; the value survives
+  its writes with no code change.
+- `services/IdpcAvailabilityService.java` (`persistCaseDocument(...)`, lines ~109–122) — leaves the
+  new field unset, so the row is created with `rag_document_reference IS NULL` in phase
+  `WAITING_FOR_UPLOAD` (AC-005). No compile or behaviour change.
+- `services/DocumentService.java`, every controller, every mapper, every OpenAPI model,
+  `version.cdk`, `acl/cdks-rules.drl`, `resources/acl/*`, any existing migration. There is no
+  `CaseDocumentMapper` and no response DTO exposes a `CaseDocument` field, so FR-009 holds with
+  zero edits (AC-007).
+
+### 3. Entity change (`CaseDocument`)
+
+One field, appended after `createdAt` (line ~85) to keep the declaration order roughly
+column-order:
+
+```java
+@Column(name = "rag_document_reference")
+private String ragDocumentReference;
+```
+
+- Lombok `@Getter`/`@Setter` on the class generate `getRagDocumentReference()` /
+  `setRagDocumentReference(String)` — no hand-written accessors, consistent with every other field.
+- `String` → `TEXT` is the mapping the app already uses for `source`, `doc_name`, `blob_uri`,
+  `content_type` and `sha256_hex`, and it satisfies `spring.jpa.hibernate.ddl-auto: validate`
+  (`application-datasource.yml:22`) without a `columnDefinition` override. This is a hard
+  constraint on the type decision, not a preference: Hibernate's startup schema validation
+  compares column types, so a `String` field over a Postgres `uuid` column fails validation at
+  boot — a `UUID` column would force the Java field (and therefore the whole call path) to
+  `java.util.UUID` and reintroduce the parse step ADR-002 rejects.
+- **Known consequence:** the class-level `@EqualsAndHashCode` has no exclusions, so the new field
+  joins `equals`/`hashCode`. Left as-is for consistency with all 14 existing fields; nothing in
+  `src/test/` or `src/integrationTest/` compares whole `CaseDocument` instances by equality (the
+  existing unit test asserts captured *fields*, see §Testing), so this is inert today. Adding
+  `@EqualsAndHashCode.Exclude` for just this field would be an inconsistent special case; fixing
+  the broader JPA-entity-equality smell is out of scope for this ticket.
+
+### 4. `RetrieveMaterialAndUploadTask` — threading and persisting the value
+
+`documentReference` is already in hand at line ~116, nine lines before the save at ~124–125. Three
+small edits, all inside the existing `try` block, no new call, no new transaction:
+
+```java
+final FileStorageLocationReturnedSuccessfully fileStorageLocation =
+        initiateDocumentUpload(documentId, materialName, documentMetadata, supersededDocumentList);
+final String documentReference = fileStorageLocation.getDocumentReference();   // (1) new local
+log.info("downloadUrl generated: {}, destinationUrl: {} ", downloadUrl, fileStorageLocation.getStorageUrl());
+
+// ... blob copy unchanged ...
+
+caseDocumentRepository.findById(documentId).ifPresent(doc ->
+        saveDocumentUploaded(doc, blobName, blobUrl, sizeBytes, documentReference));   // (2) pass it in
+
+// ... unchanged: still forwarded through job data to the next task (FR-006)
+updatedJobData.add(CTX_DOC_REFERENCE_KEY, documentReference);   // (3) reuse the local, same value
+```
+
+Edit (3) is a readability-only substitution — `updatedJobData.add(CTX_DOC_REFERENCE_KEY, ...)`
+receives exactly the same expression value as today, including the same
+`NullPointerException`-on-null behaviour from `JsonObjectBuilder.add(String, String)` (see §6).
+The local is effectively final, so the lambda capture in (2) compiles.
+
+The write itself:
+
+```java
+private void saveDocumentUploaded(final CaseDocument doc, final String blobName, final String blobUrl,
+                                  final long sizeBytes, final String documentReference) {
+    doc.setDocName(blobName);
+    doc.setBlobUri(blobUrl);
+    doc.setContentType(uploadProperties.contentType());
+    doc.setSizeBytes(sizeBytes);
+    doc.setUploadedAt(utcNow());
+    doc.setIngestionPhase(DocumentIngestionPhase.UPLOADED);
+    doc.setIngestionPhaseAt(utcNow());
+    doc.setRagDocumentReference(isBlank(documentReference) ? null : documentReference);
+    caseDocumentRepository.saveAndFlush(doc);
+}
+```
+
+- **One `saveAndFlush`, unchanged** — the new field rides the same single write as `docName`,
+  `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase = UPLOADED`,
+  `ingestionPhaseAt` (FR-002, AC-002).
+- **Stored verbatim.** No trim, no case-fold, no `UUID.fromString`, no `TaskUtils.normalise(...)`
+  truncation, no re-formatting (AC-001). The only mapping applied is blank → `NULL`, so that
+  `rag_document_reference IS NULL` is the single, unambiguous predicate for "no reference
+  recorded" across AC-004/AC-005/AC-006 — a zero-length string carries no provenance and would
+  just create a second "absent" representation.
+- `isBlank` is `io.micrometer.common.util.StringUtils.isBlank`, already statically imported in this
+  file (line 3); it is null-safe, so no separate null guard is needed.
+- **Fifth parameter is fine for PMD.** `.github/pmd-ruleset.xml` includes only the `bestpractices`,
+  `codestyle`, `errorprone`, `performance` and `security` categories — the `design` category (which
+  owns `ExcessiveParameterList`, default threshold 10) is not enabled, so NFR-007's contingency
+  does not bite. An explicit `String documentReference` parameter is preferred over passing
+  `FileStorageLocationReturnedSuccessfully` into the persistence helper, which would couple a
+  private DB-write method to a generated RAG API model. If this parameter list grows again, the
+  right refactor is a small local record (e.g. `UploadedBlob(blobName, blobUrl, sizeBytes)`), not a
+  PMD suppression.
+
+### 5. Survival across later phase transitions and task retries (FR-005, FR-006)
+
+`CheckIngestionStatusForAllDefendantsTask.updateIngestionPhase(...)` (lines ~239–245) re-reads the
+row and mutates only the two phase fields before saving:
+
+```java
+caseDocumentRepository.findById(documentId).ifPresent(doc -> {
+    doc.setIngestionPhase(phase);
+    doc.setIngestionPhaseAt(utcNow());
+    caseDocumentRepository.saveAndFlush(doc);
+});
+```
+
+Because the entity is hydrated from the row (not constructed fresh), `ragDocumentReference` is
+loaded and written back unchanged for every transition to `INGESTED`, `FAILED` and
+`EXCEEDED_FILE_SIZE_LIMIT` (AC-003). **No change is required in that task**, and its job-data read
+of `CTX_DOC_REFERENCE_KEY` (line ~79) and status polling are untouched (FR-006).
+
+**One clarification on FR-005's "written once, never overwritten".** That holds for *phase
+transitions*, which is what FR-005 is about. It does not hold — and should not — for a **retry of
+`RETRIEVE_MATERIAL_AND_UPLOAD` itself**: a retry calls `initiateDocumentUpload(...)` again, gets a
+new `documentReference`, and overwrites the column. That is correct behaviour: the stored reference
+must identify the ingestion transaction that produced the blob currently recorded in `blob_uri`,
+and the retry has just replaced it. Deliberately **not** using a write-once guard (e.g.
+`COALESCE`-style "only set if currently null"), which would leave the row pointing at a superseded,
+abandoned ingestion transaction. `CaseDocument` has no `@Version` field, so this is plain
+last-write-wins, consistent with how every other field on this row already behaves. Worth an
+explicit assertion at Test Specs stage so the semantics are pinned rather than incidental.
+
+### 6. Error handling
+
+No new error path, and no new `try`/`catch`.
+
+| Input from RAG | Behaviour |
+|---|---|
+| Valid UUID-shaped `documentReference` | Stored verbatim; flow unchanged. |
+| Non-UUID-shaped, non-blank (e.g. `"not-a-uuid"`) | **Stored verbatim.** No exception, no null, no truncation. The same value is then forwarded to job data and later passed to `documentStatusByReference(...)`, where RAG's documented `400 — documentReference is not a valid uuid` is handled by `CheckIngestionStatusForAllDefendantsTask`'s existing error handling exactly as it would be today. CDKS records what it was given; validating it is the contract owner's job. This is the AC-014 behaviour (ADR-002). |
+| `null` or blank | Column left `NULL`. `saveDocumentUploaded(...)` completes normally — the added line cannot throw, because `isBlank(...)` is null-safe and `setRagDocumentReference(null)` is a plain field assignment. The **pre-existing** behaviour then takes over unchanged: `updatedJobData.add(CTX_DOC_REFERENCE_KEY, null)` throws `NullPointerException` per the `jakarta.json.JsonObjectBuilder` contract, which the method-level `catch (Exception ex)` converts into `ExecutionStatus.INPROGRESS` + `withShouldRetry(true)` (lines ~150–158). Net effect, identical to today apart from the new column: the row is left at `UPLOADED` with `rag_document_reference IS NULL` and the task retries (FR-007, AC-004). |
+| `initiateDocumentUpload(...)` returns a `null` body | Already fails **before** the save — `fileStorageLocation.getStorageUrl()` is dereferenced at line ~117 — and is caught into the same retry. Unchanged. |
+
+The `try`-block-then-NPE sequence in the null case (row already saved as `UPLOADED`, then retry) is
+a pre-existing wart in this task, not introduced or worsened here; fixing it is out of scope and
+should not be smuggled into this change.
+
+### 7. Open questions: status after this design
+
+| OQ | Status |
+|---|---|
+| OQ-002 (column name) | **Resolved — ADR-001:** `rag_document_reference`. |
+| OQ-003 (SQL type + fallback) | **Resolved — ADR-002:** `TEXT`, verbatim, no parse, no CHECK; malformed values stored as-is. |
+| OQ-005 (index) | **Design position: no index** (FR-010). Nothing queries by reference. If an ops lookup need is confirmed, it is a separate additive migration; `TEXT` does not constrain that option. |
+| OQ-001, OQ-004, OQ-006, OQ-007 | **Carried forward unchanged** with their Stage 1 owners and due dates. None of them alters the design in §1–§6; OQ-001 (ticket text) and OQ-006 (does the ticket actually want the status task to read from the row instead of job data?) are the two that could reopen scope, and both are due before Stage 3. |
+
+---
+
+## Testing
+
+Scoping only — Test Specs stage owns the actual scenarios.
+
+**Unit (`src/test/`)**
+
+| Target | Covers |
+|---|---|
+| `RetrieveMaterialAndUploadTaskTest` (extend) | The existing `ArgumentCaptor<CaseDocument> caseDocumentCaptor` (already declared, line ~82) and `verify(caseDocumentRepository).saveAndFlush(caseDocumentCaptor.capture())` (line ~222) are the seam. Assert **one** `saveAndFlush` whose captured entity carries `ragDocumentReference` equal to the stubbed `documentReference` *plus* the existing `docName`/`blobUri`/`contentType`/`sizeBytes`/`uploadedAt`/`ingestionPhase = UPLOADED` values (AC-001, AC-002). |
+| `RetrieveMaterialAndUploadTaskTest` (new cases) | (a) `documentReference` = a deliberately non-UUID string → captured entity holds that exact string, unmodified, and no exception escapes the persistence step (**AC-014** — the explicit test the AC demands). (b) `documentReference` = `null`, and (c) = `""` → captured entity's `ragDocumentReference` is `null`, `saveAndFlush` still invoked once, and the returned `ExecutionInfo` is the unchanged `INPROGRESS`/`shouldRetry` retry outcome (AC-004, FR-007). |
+| `CheckIngestionStatusForAllDefendantsTaskTest` (extend) | For at least the `INGESTED` and one failure transition, stub `findById` to return an entity that already has `ragDocumentReference` set and assert the captured saved entity still carries the original value (AC-003, FR-005). Also confirm the suite compiles/passes unchanged otherwise (AC-010). |
+
+No `TaskUtils` test is needed — nothing is added there (contrast DD-43084, which extended
+`buildAnswerParams`).
+
+**Integration (`src/integrationTest/`)** — asserts the value survives end-to-end and not just in a
+mocked unit (AC-011, NFR-005).
+
+Recommended shape: a dedicated live test mirroring DD-43084's
+`jobmanager/queryflow/CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` — seed a `jobs` row
+addressed to `RETRIEVE_MATERIAL_AND_UPLOAD` with the job-data shape its predecessor produces, let
+the live app's `JobExecutor` run the real task against the real DB, Azurite and the RAG WireMock
+stub, then assert `rag_document_reference` via JDBC with Awaitility. That class already establishes
+the whole pattern (job seeding, `openConnection()`, `Awaitility.await()`, `finally` cleanup),
+including the `case_documents` seeding idiom available in
+`IngestionProcessByCaseHttpLiveTest` (raw `INSERT INTO case_documents`, line ~136).
+
+**Stub caveat to resolve at Test Specs stage — do not assume the fixed fixture value is what the
+app sees.** There are *two* stubs on `POST /document-upload`:
+
+1. the static mapping `wiremock/mappings/document_upload_to_generate_url.json`, with a **fixed**
+   `documentReference` of `b181b0b0-628e-4491-9ccd-2ea93d70cb2f`; and
+2. the programmatic scenario stub `DocumentIngestionInitiationApiStub.stubInitiateDocumentUpload(...)`,
+   registered by `IngestionProcessHttpLiveTest` (lines ~228, ~343) and
+   `IngestionProcessByCaseHttpLiveTest` (line ~78), which returns `randomUUID().toString()` per
+   response.
+
+WireMock is a shared container for the whole `integration` run and later-registered stubs of equal
+priority win, and the scenario's final stub keeps matching once its state settles — so if either
+`IngestionProcess*HttpLiveTest` has already run, the fixed-value mapping is shadowed and a
+hard-coded expectation of `b181b0b0-…` will flake on test ordering. Pick one of:
+
+- **(preferred)** have the new IT register its own `POST /document-upload` stub with an explicit
+  higher `withPriority(...)` and a known fixed `documentReference`, then assert exact equality; or
+- assert against the value WireMock actually served, read back from its request/response journal; or
+- assert only that the column is non-null and equals the value the flow also placed in job data.
+
+Also in scope for the IT pass, both assertion-only:
+
+- `IngestionProcessByCaseHttpLiveTest`, `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`,
+  `DocumentHttpLiveTest` run **unmodified and green** — no response body gains a field (AC-007), and
+  the raw `INSERT INTO case_documents (...)` in `IngestionProcessByCaseHttpLiveTest` keeps working
+  precisely because the column is nullable (NFR-004).
+- App startup succeeds against a database migrated from `V1012` with pre-existing
+  `case_documents` rows — which is also the live proof that `ddl-auto: validate` accepts the new
+  `String` → `TEXT` mapping (AC-006, AC-009).
+
+**Contract tests:** none — no contract change (FR-009); `pactVerificationTest` unaffected, and the
+consumed `api-cp-ai-rag` / `api-cp-crime-caseadmin-case-document-knowledge` artefact versions are
+untouched.
+
+**Quality gates:** `gradle clean build` (including `integration`), PMD and JaCoCo green at existing
+unmodified thresholds, CodeQL and secrets scanner clean (AC-012). All new fixtures/values synthetic;
+no PII, case content, court reference number or real `CJSCPPUID` (AC-013).

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/03-stories.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/03-stories.md
@@ -6,215 +6,90 @@
 > [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) (Story 2),
 > [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) (Story 3).
 >
-> Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
-> so each story is ready to paste into its Jira ticket; ADR-001 (column name
-> `rag_document_reference`) and ADR-002 (SQL type `TEXT`, verbatim, no parse, no CHECK) —
-> [`adrs/DD-43083-persist-doc-ingestion-transaction-id.md`](../adrs/DD-43083-persist-doc-ingestion-transaction-id.md)
-> — are both **Accepted** and are locked decisions, not reopened here.
+> Acceptance Criteria embedded verbatim from [`01-requirements.md`](./01-requirements.md), which
+> also holds the full NFR list — only cited here where a story's own testing depends on one. ADR-001
+> (column name `rag_document_reference`) and ADR-002 (SQL type `TEXT`, verbatim, no parse, no
+> CHECK) — [ADRs](../adrs/DD-43083-persist-doc-ingestion-transaction-id.md) — are **Accepted** and
+> not reopened here.
 >
-> **Structure note.** This ticket does not mirror DD-43084's four-way split. DD-43084 needed a
-> separate "keep read-side entities in sync" story because its write path was raw
-> `NamedParameterJdbcTemplate` upsert SQL, independent of the JPA entity. Here there is a single
-> entity (`CaseDocument`), a single write point (`saveDocumentUploaded(...)`'s existing
-> `saveAndFlush`), and no upsert — the entity change *is* the write-path change, so Stage 1's
-> candidate Story 2 (entity + persistence) and Story 3 (survival across phase transitions) are
-> merged below into one story, exactly as Stage 1 flagged as an option ("assertion-only, with no
-> production change of its own beyond what Story 2 delivers"). Net result: **three stories**, not
-> four — schema, persistence (incl. survival across later phases), and end-to-end test coverage.
+> **Three stories, not four.** Unlike DD-43084 (raw-SQL upsert, so the JPA entity needed its own
+> "keep read-side in sync" story), this ticket has a single entity and a single write point —
+> the entity change *is* the persistence change — so Stage 1's candidate stories 2 and 3 are merged.
 
-**Standard DoD (applies to every story unless noted)**: code reviewed & approved · all ACs
-covered by automated tests (unit + integration) · no critical/high Snyk findings introduced ·
-deployed to and verified on sandbox · Jira ticket updated with test evidence. Deltas only, below.
+**Standard DoD (every story)**: code reviewed & approved · ACs covered by automated tests (unit +
+integration) · no critical/high Snyk findings · deployed to and verified on sandbox · Jira updated
+with test evidence.
 
 ---
 
 ## Story 1 — Add `rag_document_reference` column to `case_documents`
 **Jira: [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136)**
 
-As a **CDKS developer**,
-I want **a new, append-only Flyway migration (`V1013`) that adds a nullable
-`rag_document_reference TEXT` column to `case_documents`, with a column comment**,
-so that **the application layer has somewhere to persist the RAG-issued ingestion
-`documentReference`, with zero risk to existing rows, constraints, or reads**.
+As a **CDKS developer**, I want **an append-only Flyway migration (`V1013`) adding a nullable
+`rag_document_reference TEXT` column to `case_documents`**, so that **the app has somewhere to
+persist the RAG ingestion reference, with zero risk to existing rows or reads**.
 
-## Background
-Column name and SQL type were the two open questions carried from Stage 1 (OQ-002, OQ-003) and
-are now settled and Accepted in ADR-001/ADR-002: `rag_document_reference`, typed `TEXT`, stored
-verbatim, no `CHECK`, no index. This story ships only the schema change — no code reads or writes
-the column yet, so it is a safe, independently deployable no-op until Story 2 lands.
+**Acceptance criteria**
+- AC-006: Rows that predate `V1013` show the column `IS NULL` — no error, no backfill.
+- AC-008: `V1013__*.sql` adds exactly one nullable column plus a `COMMENT ON COLUMN` — no rename, no drop, no `NOT NULL`, no default — reviewed by `migration-reviewer`.
+- AC-009: Flyway migrates cleanly on a fresh DB and on a DB already at `V1012` with existing rows; `gradle integration` starts and the app reaches readiness.
 
-## Acceptance criteria
-- [ ] AC-006: Rows that predate the `V1013` migration show the new column `IS NULL` — no error, no backfill attempted.
-- [ ] AC-008: `V1013__*.sql` adds exactly one nullable column to `case_documents`, plus a `COMMENT ON COLUMN` explaining the field and its nullability — no rename, no drop, no `NOT NULL`, no default, no data rewrite, no change to any other table — and is reviewed by `migration-reviewer` before merge.
-- [ ] AC-009: Flyway migrates cleanly both on a fresh database and on a database already at `V1012` with existing `case_documents` rows; the `gradle integration` compose stack starts and the app reaches readiness.
-
-## NFR links
-- NFR-003 (Migration safety): `ALTER TABLE ... ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL 16 — no table rewrite, no lock escalation, no default backfill.
-- NFR-006 (Migration governance): routed through `migration-reviewer`; shipped `V1000`–`V1012` are never edited.
-
-## Out of scope for this story
-- Any code that reads or writes the new column (Story 2)
-- An index on the new column (FR-010; no query-by-reference read path exists today — see OQ-005, deferred)
-- Backfilling historic rows (FR-008)
-
-## Definition of done
-- [ ] Code reviewed and approved
-- [ ] All ACs covered by automated tests (unit + integration)
-- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
-- [ ] No critical or high Snyk findings introduced
-- [ ] Deployed to and verified on sandbox
-- [ ] Jira ticket updated with test evidence
-- [ ] **DoD delta:** `migration-reviewer` review completed and evidenced on the ticket for `V1013__add_rag_document_reference_to_case_documents.sql`; `gradle integration` confirmed green against a database already at `V1012` with existing rows (not just a fresh DB)
-
-## Dependencies
-- Blocks Story 2 (nothing to write to until the column exists)
-- Independently deployable/reversible on its own — a no-op until Story 2 lands
-
-## Notes / open questions
-- OQ-004 (external consumers of `case_documents`) and OQ-005 (support/ops lookup-by-reference need,
-  which would require a separate additive index migration) are carried forward unresolved; neither
-  blocks this story.
+**Notes:** schema-only, no code reads/writes it yet — a safe no-op until Story 2 lands, and blocks
+it. `ADD COLUMN ... NULL` is metadata-only on PostgreSQL 16 (NFR-002).
 
 ---
 
-## Story 2 — Persist and preserve the RAG `documentReference` on `case_documents`
+## Story 2 — Persist and preserve the RAG `documentReference`
 **Jira: [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137)**
 
-As a **support/ops engineer investigating a document ingestion**,
-I want **every uploaded document row to record the exact RAG `documentReference` that produced it,
-and to keep that value unchanged through every later ingestion-status transition**,
-so that **I can trace any stored document back to the exact upstream RAG ingestion transaction,
-closing the ingestion-side half of the traceability gap DD-43084 closed on the answer side**.
+As a **support/ops engineer investigating a document ingestion**, I want **every uploaded document
+row to record the exact RAG `documentReference` that produced it, unchanged through every later
+ingestion-status transition**, so that **I can trace a stored document back to the upstream RAG
+transaction — the ingestion-side half of what DD-43084 did for answers**.
 
-## Background
-`documentReference` is already resolved in `RetrieveMaterialAndUploadTask` a few lines before the
-existing `saveDocumentUploaded(...)` call that updates the same `case_documents` row (design §2,
-§4). This story adds the mapped `CaseDocument` field and threads the value into that single
-existing `saveAndFlush` — no new write, no second transaction, no new repository method, no new
-`TaskUtils` helper (ADR-002 rules out a parse step). Because `CaseDocument` is hydrated from the
-row rather than constructed fresh, `CheckIngestionStatusForAllDefendantsTask`'s later phase-
-transition saves (`INGESTED` / `FAILED` / `EXCEEDED_FILE_SIZE_LIMIT`) carry the value forward
-automatically with **no code change in that task** (design §5) — this is asserted, not built, so
-it is folded into this story rather than split out, per Stage 1's explicit note that it "may be
-folded into Story 2 if reviewers prefer."
+**Acceptance criteria**
+- AC-001: The value is preserved exactly as received — no truncation, trimming, case-folding, or re-formatting.
+- AC-002: Written in the same `saveAndFlush` as `docName`/`blobUri`/`contentType`/`sizeBytes`/`uploadedAt`/`ingestionPhase = UPLOADED` — one write, not two.
+- AC-003: Survives later transitions to `INGESTED`, `FAILED`, `EXCEEDED_FILE_SIZE_LIMIT` — not nulled, not changed.
+- AC-004: A `null`/blank reference leaves the column `NULL`; task outcome (retry) is unchanged from today.
+- AC-005: A `WAITING_FOR_UPLOAD` row (from `IdpcAvailabilityService`) shows the column `IS NULL` until upload initiation completes.
+- AC-010: `RetrieveMaterialAndUploadTaskTest` / `CheckIngestionStatusForAllDefendantsTaskTest` compile and pass with updated signatures.
+- AC-014: A non-UUID-shaped reference is neither silently discarded nor allowed to fail the ingestion flow (ADR-002).
 
-The one exception to "written once, never changed" is a **retry** of
-`RETRIEVE_MATERIAL_AND_UPLOAD` itself: a retry calls `initiateDocumentUpload(...)` again and the
-new reference correctly overwrites the old one, last-write-wins, because it must identify the
-ingestion transaction that produced the blob currently recorded in `blob_uri` (design §5). This is
-deliberate and should be pinned by a test, not treated as a regression.
-
-## Acceptance criteria
-- [ ] AC-001: Given a `RETRIEVE_MATERIAL_AND_UPLOAD` execution where `initiateDocumentUpload(...)` returns a `documentReference`, when the task completes successfully, then the `case_documents` row for that `doc_id` holds that value in the new column — preserved exactly as received, with no truncation, trimming, case-folding, or re-formatting.
-- [ ] AC-002: The value is written in the **same** `saveAndFlush` as `docName`, `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase = UPLOADED` — verified by a unit test that captures the `CaseDocument` passed to `CaseDocumentRepository.saveAndFlush(...)` and asserts a single invocation carrying all of those fields plus the new one.
-- [ ] AC-003: Given a row with the value persisted, when `CheckIngestionStatusForAllDefendantsTask` subsequently transitions the phase to `INGESTED`, `FAILED`, or `EXCEEDED_FILE_SIZE_LIMIT`, then the new column still holds the original value — not nulled, not changed.
-- [ ] AC-004: Given RAG returns a null or blank `documentReference`, when the task runs, then the new persistence code throws no exception of its own and the task's existing outcome (retry via `ExecutionStatus.INPROGRESS`) is unchanged from current behaviour; any row written shows the new column `IS NULL`.
-- [ ] AC-005: A row created by `IdpcAvailabilityService.persistCaseDocument(...)` in phase `WAITING_FOR_UPLOAD` shows the new column `IS NULL` until upload initiation completes for that document.
-- [ ] AC-010: `RetrieveMaterialAndUploadTaskTest` and `CheckIngestionStatusForAllDefendantsTaskTest` compile and pass with any updated signatures.
-- [ ] AC-014: Whichever SQL type Design settled on (`TEXT`, per ADR-002), a `documentReference` that does not match the RAG contract's UUID pattern must neither (a) be silently discarded nor (b) fail the ingestion flow. The chosen behaviour is recorded in the ADR and covered by an explicit test.
-
-## NFR links
-- NFR-001 (Data protection): `documentReference` is an opaque, RAG-issued correlation string, already logged at INFO by both tasks today — persisting it introduces no new data-protection exposure.
-- NFR-004 (Backward compatibility): no change to any GET response shape or SQL read path; `IdpcAvailabilityService` and `DocumentService` keep compiling and behaving unchanged.
-- NFR-007 (Code quality): PMD/JaCoCo pass at existing thresholds with no new suppressions; the extra `saveDocumentUploaded(...)` parameter stays within the enabled PMD rule categories (design §4).
-- NFR-008 (Platform): the existing Spring Data JPA `saveAndFlush` pattern is preserved — no raw SQL introduced on this path.
-- NFR-009 (Logging): no new log statement required; JSON-to-stdout logging and no-document-body-logged rules unchanged.
-
-## Out of scope for this story
-- Any API/contract exposure of the field, or a lookup-by-reference endpoint (FR-009, out of scope for the whole requirement)
-- An index on the new column (FR-010)
-- Refactoring `CheckIngestionStatusForAllDefendantsTask` to read the reference from `case_documents` instead of job data (OQ-006) — job-data threading via `CTX_DOC_REFERENCE_KEY` is explicitly unchanged (FR-006)
-- Backfilling historic rows (FR-008)
-- A write-once guard against retry overwrites — last-write-wins is the intended behaviour (design §5)
-
-## Definition of done
-- [ ] Code reviewed and approved
-- [ ] All ACs covered by automated tests (unit + integration)
-- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
-- [ ] No critical or high Snyk findings introduced
-- [ ] Deployed to and verified on sandbox
-- [ ] Jira ticket updated with test evidence
-- [ ] **DoD delta:** `RetrieveMaterialAndUploadTaskTest` extended with explicit non-UUID-shaped-string, `null`, and `""` cases against the captured `CaseDocument` (AC-014, AC-004); `CheckIngestionStatusForAllDefendantsTaskTest` extended to stub an already-populated `ragDocumentReference` and assert it survives at least the `INGESTED` and one failure transition (AC-003); a retry-of-`RETRIEVE_MATERIAL_AND_UPLOAD` overwrite case is asserted so the last-write-wins semantic is pinned, not incidental (design §5)
-
-## Dependencies
-- Needs Story 1's column to exist first
-- Supersedes Stage 1's candidate "Story 3" (no regression on the ingestion status path) — folded in here because it is assertion-only with no production change of its own beyond what this story already delivers (`CheckIngestionStatusForAllDefendantsTask` requires **zero code changes**)
-
-## Notes / open questions
-- OQ-001 (confirm the restated scope matches the literal Jira ticket text) and OQ-006 (confirm the
-  ticket doesn't actually want the status task to read the reference from the row instead of job
-  data) are both still open per Stage 1 and are due before implementation of this story begins —
-  if either resolves differently, this story's scope may need revisiting.
-- OQ-007 (retention/purge — assumed the column simply inherits the parent row's policy) is still
-  open; flag to data-protection review before merge.
+**Notes:** needs Story 1's column. Retries of `RETRIEVE_MATERIAL_AND_UPLOAD` overwrite the stored
+reference (last-write-wins, intended — design §5), and `CheckIngestionStatusForAllDefendantsTask`
+needs **no code change** since it re-saves the hydrated entity (folds in Stage 1's candidate Story
+3). OQ-001/OQ-006 (scope vs. the literal ticket text) should be settled before this is picked up.
 
 ---
 
 ## Story 3 — End-to-end test coverage for `rag_document_reference`
 **Jira: [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138)**
 
-As a **CDKS developer**,
-I want **an integration test proving `rag_document_reference` is populated through the real
-ingestion flow (real DB, Azurite, and the RAG WireMock stub), not just asserted against a mocked
-repository call**,
-so that **persistence of the RAG ingestion reference is proven end-to-end, and existing API/response
-behaviour is confirmed unaffected**.
+As a **CDKS developer**, I want **an integration test proving the column is populated through the
+real ingestion flow**, so that **persistence is proven end-to-end and existing API behaviour is
+confirmed unaffected** (NFR-003).
 
-## Background
-Stage 1 requires the value to be proven live, not just unit-mocked (NFR-005), and requires proof
-that no API surface changed (AC-007). Design flags a real ordering hazard to resolve here rather
-than assume away: `POST /document-upload` has **two** WireMock stubs in the shared `integration`
-compose container — a static mapping with a fixed `documentReference`
-(`wiremock/mappings/document_upload_to_generate_url.json`) and a programmatic scenario stub
-(`DocumentIngestionInitiationApiStub`) used by the `IngestionProcess*HttpLiveTest` suites that
-returns a fresh `randomUUID()` per response and can shadow the static mapping depending on test
-run order (design §Testing, "Stub caveat"). This story must pick one of the design's three
-mitigations (dedicated higher-priority stub with a known fixed value; assert against WireMock's
-own request/response journal; or assert only that the column is non-null and matches the value
-also placed in job data) rather than hard-coding the static mapping's fixed UUID and risking a
-flake on suite ordering.
+**Acceptance criteria**
+- AC-007: No controller/DTO/mapper change; `version.cdk` unchanged; existing `*HttpLiveTest` suites pass unmodified.
+- AC-011: A live test asserts the column is populated from the RAG WireMock stub after the flow reaches `UPLOADED`.
+- AC-012: `gradle clean build` (incl. `integration`) passes; PMD/JaCoCo/CodeQL/secrets-scanner clean.
+- AC-013: No PII/case content/court reference/`CJSCPPUID` in the diff; fixtures stay synthetic.
 
-## Acceptance criteria
-- [ ] AC-007: No controller, response DTO, or mapper changes; `version.cdk` is unchanged; `IngestionProcessByCaseHttpLiveTest` (and every other existing `*HttpLiveTest`) passes with its assertions unmodified.
-- [ ] AC-011: An integration test asserts the new column is populated with the stubbed `documentReference` from `document_upload_to_generate_url.json` after the ingestion flow reaches `UPLOADED`, i.e. the value survives end-to-end and not just in a mocked unit.
-- [ ] AC-012: `gradle clean build` (including `integration`) passes; PMD and JaCoCo are green at existing, unmodified thresholds; CodeQL and the secrets scanner are clean.
-- [ ] AC-013: The diff introduces no PII, case content, court reference number, or `CJSCPPUID` into the migration, tests, or fixtures; WireMock/Azurite fixture values remain synthetic.
-
-## NFR links
-- NFR-005 (Testability): dedicated `integrationTest` coverage against the existing WireMock stub, run as part of `gradle integration` against the full compose stack.
-- NFR-004 (Backward compatibility): existing `*HttpLiveTest` suites (`IngestionProcessByCaseHttpLiveTest`, `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`, `DocumentHttpLiveTest`) confirmed unmodified and green, and the raw `INSERT INTO case_documents (...)` fixture in `IngestionProcessByCaseHttpLiveTest` keeps working because the column is nullable.
-
-## Out of scope for this story
-- Any production code change — this story is test-only, layered on top of Story 1 and Story 2
-- Contract tests — no contract change (FR-009); `pactVerificationTest` is unaffected and out of scope here
-
-## Definition of done
-- [ ] Code reviewed and approved
-- [ ] All ACs covered by automated tests (unit + integration)
-- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
-- [ ] No critical or high Snyk findings introduced
-- [ ] Deployed to and verified on sandbox
-- [ ] Jira ticket updated with test evidence
-- [ ] **DoD delta:** new live test (mirroring the pattern of `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` from DD-43084 — job seeding, real `JobExecutor`, `openConnection()` + `Awaitility.await()`, `finally` cleanup) added under `src/integrationTest/`, resolving the two-stub ordering hazard explicitly (design §Testing "Stub caveat") rather than assuming the static mapping wins; app-startup-against-a-`V1012`-database-with-existing-rows confirmed as the live proof that `ddl-auto: validate` accepts the new `String`→`TEXT` mapping (AC-006/AC-009, cross-checked against Story 1)
-
-## Dependencies
-- Needs Story 1 (column must exist) and Story 2 (persistence code must exist) to be meaningful; can be scoped and drafted in parallel but cannot pass CI until both have merged
-- Closes out NFR-005 and the remaining untested ACs (AC-007, AC-011, AC-012, AC-013) left after Stories 1–2
-
-## Notes / open questions
-- The WireMock stub-ordering hazard (design §Testing) is a genuine implementation risk, not a
-  documentation nicety — flag to the assigned developer before they write the IT, so they choose
-  one of the three documented mitigations deliberately rather than discovering the flake later.
+**Notes:** needs Stories 1 and 2 merged first. `POST /document-upload` has two colliding WireMock
+stubs in the shared compose container (a fixed-value static mapping and a `randomUUID()`
+programmatic stub used by other live tests) — the new test must register its own
+higher-priority, narrowly-matched stub rather than assume the static mapping wins (design
+§Testing "Stub caveat"). No contract tests — no contract change.
 
 ---
 
-## Summary for review
+## Summary
 
-| Story | Jira | Covers | Depends on |
-|---|---|---|---|
-| 1 — Schema migration | [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136) | FR-003, AC-006, AC-008, AC-009 | none |
-| 2 — Persist + preserve across phase transitions | [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) | FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-008, AC-001–AC-005, AC-010, AC-014 | Story 1 |
-| 3 — End-to-end test coverage | [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) | NFR-005, AC-007, AC-011, AC-012, AC-013 | Stories 1 & 2 |
+| Story | Jira | Depends on |
+|---|---|---|
+| 1 — Schema migration | [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136) | none |
+| 2 — Persist + preserve | [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) | Story 1 |
+| 3 — Test coverage | [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) | Stories 1 & 2 |
 
-**Not a story in this requirement** (per Stage 1, unchanged): any API exposure of the field, a
-lookup-by-reference endpoint, or a backfill job.
+**Not a story here** (per Stage 1, unchanged): API exposure, a lookup-by-reference endpoint, or a backfill job.

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/03-stories.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/03-stories.md
@@ -1,0 +1,220 @@
+# User Stories: Persist RAG Document-Ingestion Reference on `case_documents`
+
+> **Stage 3 — User Story** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Parent Jira: DD-43083** — each story below has its own sub-ticket:
+> [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136) (Story 1),
+> [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) (Story 2),
+> [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) (Story 3).
+>
+> Acceptance Criteria text below is embedded verbatim from [`01-requirements.md`](./01-requirements.md)
+> so each story is ready to paste into its Jira ticket; ADR-001 (column name
+> `rag_document_reference`) and ADR-002 (SQL type `TEXT`, verbatim, no parse, no CHECK) —
+> [`adrs/DD-43083-persist-doc-ingestion-transaction-id.md`](../adrs/DD-43083-persist-doc-ingestion-transaction-id.md)
+> — are both **Accepted** and are locked decisions, not reopened here.
+>
+> **Structure note.** This ticket does not mirror DD-43084's four-way split. DD-43084 needed a
+> separate "keep read-side entities in sync" story because its write path was raw
+> `NamedParameterJdbcTemplate` upsert SQL, independent of the JPA entity. Here there is a single
+> entity (`CaseDocument`), a single write point (`saveDocumentUploaded(...)`'s existing
+> `saveAndFlush`), and no upsert — the entity change *is* the write-path change, so Stage 1's
+> candidate Story 2 (entity + persistence) and Story 3 (survival across phase transitions) are
+> merged below into one story, exactly as Stage 1 flagged as an option ("assertion-only, with no
+> production change of its own beyond what Story 2 delivers"). Net result: **three stories**, not
+> four — schema, persistence (incl. survival across later phases), and end-to-end test coverage.
+
+**Standard DoD (applies to every story unless noted)**: code reviewed & approved · all ACs
+covered by automated tests (unit + integration) · no critical/high Snyk findings introduced ·
+deployed to and verified on sandbox · Jira ticket updated with test evidence. Deltas only, below.
+
+---
+
+## Story 1 — Add `rag_document_reference` column to `case_documents`
+**Jira: [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136)**
+
+As a **CDKS developer**,
+I want **a new, append-only Flyway migration (`V1013`) that adds a nullable
+`rag_document_reference TEXT` column to `case_documents`, with a column comment**,
+so that **the application layer has somewhere to persist the RAG-issued ingestion
+`documentReference`, with zero risk to existing rows, constraints, or reads**.
+
+## Background
+Column name and SQL type were the two open questions carried from Stage 1 (OQ-002, OQ-003) and
+are now settled and Accepted in ADR-001/ADR-002: `rag_document_reference`, typed `TEXT`, stored
+verbatim, no `CHECK`, no index. This story ships only the schema change — no code reads or writes
+the column yet, so it is a safe, independently deployable no-op until Story 2 lands.
+
+## Acceptance criteria
+- [ ] AC-006: Rows that predate the `V1013` migration show the new column `IS NULL` — no error, no backfill attempted.
+- [ ] AC-008: `V1013__*.sql` adds exactly one nullable column to `case_documents`, plus a `COMMENT ON COLUMN` explaining the field and its nullability — no rename, no drop, no `NOT NULL`, no default, no data rewrite, no change to any other table — and is reviewed by `migration-reviewer` before merge.
+- [ ] AC-009: Flyway migrates cleanly both on a fresh database and on a database already at `V1012` with existing `case_documents` rows; the `gradle integration` compose stack starts and the app reaches readiness.
+
+## NFR links
+- NFR-003 (Migration safety): `ALTER TABLE ... ADD COLUMN ... NULL` is additive and metadata-only on PostgreSQL 16 — no table rewrite, no lock escalation, no default backfill.
+- NFR-006 (Migration governance): routed through `migration-reviewer`; shipped `V1000`–`V1012` are never edited.
+
+## Out of scope for this story
+- Any code that reads or writes the new column (Story 2)
+- An index on the new column (FR-010; no query-by-reference read path exists today — see OQ-005, deferred)
+- Backfilling historic rows (FR-008)
+
+## Definition of done
+- [ ] Code reviewed and approved
+- [ ] All ACs covered by automated tests (unit + integration)
+- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
+- [ ] No critical or high Snyk findings introduced
+- [ ] Deployed to and verified on sandbox
+- [ ] Jira ticket updated with test evidence
+- [ ] **DoD delta:** `migration-reviewer` review completed and evidenced on the ticket for `V1013__add_rag_document_reference_to_case_documents.sql`; `gradle integration` confirmed green against a database already at `V1012` with existing rows (not just a fresh DB)
+
+## Dependencies
+- Blocks Story 2 (nothing to write to until the column exists)
+- Independently deployable/reversible on its own — a no-op until Story 2 lands
+
+## Notes / open questions
+- OQ-004 (external consumers of `case_documents`) and OQ-005 (support/ops lookup-by-reference need,
+  which would require a separate additive index migration) are carried forward unresolved; neither
+  blocks this story.
+
+---
+
+## Story 2 — Persist and preserve the RAG `documentReference` on `case_documents`
+**Jira: [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137)**
+
+As a **support/ops engineer investigating a document ingestion**,
+I want **every uploaded document row to record the exact RAG `documentReference` that produced it,
+and to keep that value unchanged through every later ingestion-status transition**,
+so that **I can trace any stored document back to the exact upstream RAG ingestion transaction,
+closing the ingestion-side half of the traceability gap DD-43084 closed on the answer side**.
+
+## Background
+`documentReference` is already resolved in `RetrieveMaterialAndUploadTask` a few lines before the
+existing `saveDocumentUploaded(...)` call that updates the same `case_documents` row (design §2,
+§4). This story adds the mapped `CaseDocument` field and threads the value into that single
+existing `saveAndFlush` — no new write, no second transaction, no new repository method, no new
+`TaskUtils` helper (ADR-002 rules out a parse step). Because `CaseDocument` is hydrated from the
+row rather than constructed fresh, `CheckIngestionStatusForAllDefendantsTask`'s later phase-
+transition saves (`INGESTED` / `FAILED` / `EXCEEDED_FILE_SIZE_LIMIT`) carry the value forward
+automatically with **no code change in that task** (design §5) — this is asserted, not built, so
+it is folded into this story rather than split out, per Stage 1's explicit note that it "may be
+folded into Story 2 if reviewers prefer."
+
+The one exception to "written once, never changed" is a **retry** of
+`RETRIEVE_MATERIAL_AND_UPLOAD` itself: a retry calls `initiateDocumentUpload(...)` again and the
+new reference correctly overwrites the old one, last-write-wins, because it must identify the
+ingestion transaction that produced the blob currently recorded in `blob_uri` (design §5). This is
+deliberate and should be pinned by a test, not treated as a regression.
+
+## Acceptance criteria
+- [ ] AC-001: Given a `RETRIEVE_MATERIAL_AND_UPLOAD` execution where `initiateDocumentUpload(...)` returns a `documentReference`, when the task completes successfully, then the `case_documents` row for that `doc_id` holds that value in the new column — preserved exactly as received, with no truncation, trimming, case-folding, or re-formatting.
+- [ ] AC-002: The value is written in the **same** `saveAndFlush` as `docName`, `blobUri`, `contentType`, `sizeBytes`, `uploadedAt`, `ingestionPhase = UPLOADED` — verified by a unit test that captures the `CaseDocument` passed to `CaseDocumentRepository.saveAndFlush(...)` and asserts a single invocation carrying all of those fields plus the new one.
+- [ ] AC-003: Given a row with the value persisted, when `CheckIngestionStatusForAllDefendantsTask` subsequently transitions the phase to `INGESTED`, `FAILED`, or `EXCEEDED_FILE_SIZE_LIMIT`, then the new column still holds the original value — not nulled, not changed.
+- [ ] AC-004: Given RAG returns a null or blank `documentReference`, when the task runs, then the new persistence code throws no exception of its own and the task's existing outcome (retry via `ExecutionStatus.INPROGRESS`) is unchanged from current behaviour; any row written shows the new column `IS NULL`.
+- [ ] AC-005: A row created by `IdpcAvailabilityService.persistCaseDocument(...)` in phase `WAITING_FOR_UPLOAD` shows the new column `IS NULL` until upload initiation completes for that document.
+- [ ] AC-010: `RetrieveMaterialAndUploadTaskTest` and `CheckIngestionStatusForAllDefendantsTaskTest` compile and pass with any updated signatures.
+- [ ] AC-014: Whichever SQL type Design settled on (`TEXT`, per ADR-002), a `documentReference` that does not match the RAG contract's UUID pattern must neither (a) be silently discarded nor (b) fail the ingestion flow. The chosen behaviour is recorded in the ADR and covered by an explicit test.
+
+## NFR links
+- NFR-001 (Data protection): `documentReference` is an opaque, RAG-issued correlation string, already logged at INFO by both tasks today — persisting it introduces no new data-protection exposure.
+- NFR-004 (Backward compatibility): no change to any GET response shape or SQL read path; `IdpcAvailabilityService` and `DocumentService` keep compiling and behaving unchanged.
+- NFR-007 (Code quality): PMD/JaCoCo pass at existing thresholds with no new suppressions; the extra `saveDocumentUploaded(...)` parameter stays within the enabled PMD rule categories (design §4).
+- NFR-008 (Platform): the existing Spring Data JPA `saveAndFlush` pattern is preserved — no raw SQL introduced on this path.
+- NFR-009 (Logging): no new log statement required; JSON-to-stdout logging and no-document-body-logged rules unchanged.
+
+## Out of scope for this story
+- Any API/contract exposure of the field, or a lookup-by-reference endpoint (FR-009, out of scope for the whole requirement)
+- An index on the new column (FR-010)
+- Refactoring `CheckIngestionStatusForAllDefendantsTask` to read the reference from `case_documents` instead of job data (OQ-006) — job-data threading via `CTX_DOC_REFERENCE_KEY` is explicitly unchanged (FR-006)
+- Backfilling historic rows (FR-008)
+- A write-once guard against retry overwrites — last-write-wins is the intended behaviour (design §5)
+
+## Definition of done
+- [ ] Code reviewed and approved
+- [ ] All ACs covered by automated tests (unit + integration)
+- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
+- [ ] No critical or high Snyk findings introduced
+- [ ] Deployed to and verified on sandbox
+- [ ] Jira ticket updated with test evidence
+- [ ] **DoD delta:** `RetrieveMaterialAndUploadTaskTest` extended with explicit non-UUID-shaped-string, `null`, and `""` cases against the captured `CaseDocument` (AC-014, AC-004); `CheckIngestionStatusForAllDefendantsTaskTest` extended to stub an already-populated `ragDocumentReference` and assert it survives at least the `INGESTED` and one failure transition (AC-003); a retry-of-`RETRIEVE_MATERIAL_AND_UPLOAD` overwrite case is asserted so the last-write-wins semantic is pinned, not incidental (design §5)
+
+## Dependencies
+- Needs Story 1's column to exist first
+- Supersedes Stage 1's candidate "Story 3" (no regression on the ingestion status path) — folded in here because it is assertion-only with no production change of its own beyond what this story already delivers (`CheckIngestionStatusForAllDefendantsTask` requires **zero code changes**)
+
+## Notes / open questions
+- OQ-001 (confirm the restated scope matches the literal Jira ticket text) and OQ-006 (confirm the
+  ticket doesn't actually want the status task to read the reference from the row instead of job
+  data) are both still open per Stage 1 and are due before implementation of this story begins —
+  if either resolves differently, this story's scope may need revisiting.
+- OQ-007 (retention/purge — assumed the column simply inherits the parent row's policy) is still
+  open; flag to data-protection review before merge.
+
+---
+
+## Story 3 — End-to-end test coverage for `rag_document_reference`
+**Jira: [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138)**
+
+As a **CDKS developer**,
+I want **an integration test proving `rag_document_reference` is populated through the real
+ingestion flow (real DB, Azurite, and the RAG WireMock stub), not just asserted against a mocked
+repository call**,
+so that **persistence of the RAG ingestion reference is proven end-to-end, and existing API/response
+behaviour is confirmed unaffected**.
+
+## Background
+Stage 1 requires the value to be proven live, not just unit-mocked (NFR-005), and requires proof
+that no API surface changed (AC-007). Design flags a real ordering hazard to resolve here rather
+than assume away: `POST /document-upload` has **two** WireMock stubs in the shared `integration`
+compose container — a static mapping with a fixed `documentReference`
+(`wiremock/mappings/document_upload_to_generate_url.json`) and a programmatic scenario stub
+(`DocumentIngestionInitiationApiStub`) used by the `IngestionProcess*HttpLiveTest` suites that
+returns a fresh `randomUUID()` per response and can shadow the static mapping depending on test
+run order (design §Testing, "Stub caveat"). This story must pick one of the design's three
+mitigations (dedicated higher-priority stub with a known fixed value; assert against WireMock's
+own request/response journal; or assert only that the column is non-null and matches the value
+also placed in job data) rather than hard-coding the static mapping's fixed UUID and risking a
+flake on suite ordering.
+
+## Acceptance criteria
+- [ ] AC-007: No controller, response DTO, or mapper changes; `version.cdk` is unchanged; `IngestionProcessByCaseHttpLiveTest` (and every other existing `*HttpLiveTest`) passes with its assertions unmodified.
+- [ ] AC-011: An integration test asserts the new column is populated with the stubbed `documentReference` from `document_upload_to_generate_url.json` after the ingestion flow reaches `UPLOADED`, i.e. the value survives end-to-end and not just in a mocked unit.
+- [ ] AC-012: `gradle clean build` (including `integration`) passes; PMD and JaCoCo are green at existing, unmodified thresholds; CodeQL and the secrets scanner are clean.
+- [ ] AC-013: The diff introduces no PII, case content, court reference number, or `CJSCPPUID` into the migration, tests, or fixtures; WireMock/Azurite fixture values remain synthetic.
+
+## NFR links
+- NFR-005 (Testability): dedicated `integrationTest` coverage against the existing WireMock stub, run as part of `gradle integration` against the full compose stack.
+- NFR-004 (Backward compatibility): existing `*HttpLiveTest` suites (`IngestionProcessByCaseHttpLiveTest`, `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`, `DocumentHttpLiveTest`) confirmed unmodified and green, and the raw `INSERT INTO case_documents (...)` fixture in `IngestionProcessByCaseHttpLiveTest` keeps working because the column is nullable.
+
+## Out of scope for this story
+- Any production code change — this story is test-only, layered on top of Story 1 and Story 2
+- Contract tests — no contract change (FR-009); `pactVerificationTest` is unaffected and out of scope here
+
+## Definition of done
+- [ ] Code reviewed and approved
+- [ ] All ACs covered by automated tests (unit + integration)
+- [ ] Accessibility audit passed (axe-core + manual check) — **N/A, no UI in this change**
+- [ ] No critical or high Snyk findings introduced
+- [ ] Deployed to and verified on sandbox
+- [ ] Jira ticket updated with test evidence
+- [ ] **DoD delta:** new live test (mirroring the pattern of `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` from DD-43084 — job seeding, real `JobExecutor`, `openConnection()` + `Awaitility.await()`, `finally` cleanup) added under `src/integrationTest/`, resolving the two-stub ordering hazard explicitly (design §Testing "Stub caveat") rather than assuming the static mapping wins; app-startup-against-a-`V1012`-database-with-existing-rows confirmed as the live proof that `ddl-auto: validate` accepts the new `String`→`TEXT` mapping (AC-006/AC-009, cross-checked against Story 1)
+
+## Dependencies
+- Needs Story 1 (column must exist) and Story 2 (persistence code must exist) to be meaningful; can be scoped and drafted in parallel but cannot pass CI until both have merged
+- Closes out NFR-005 and the remaining untested ACs (AC-007, AC-011, AC-012, AC-013) left after Stories 1–2
+
+## Notes / open questions
+- The WireMock stub-ordering hazard (design §Testing) is a genuine implementation risk, not a
+  documentation nicety — flag to the assigned developer before they write the IT, so they choose
+  one of the three documented mitigations deliberately rather than discovering the flake later.
+
+---
+
+## Summary for review
+
+| Story | Jira | Covers | Depends on |
+|---|---|---|---|
+| 1 — Schema migration | [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136) | FR-003, AC-006, AC-008, AC-009 | none |
+| 2 — Persist + preserve across phase transitions | [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) | FR-001, FR-002, FR-004, FR-005, FR-006, FR-007, FR-008, AC-001–AC-005, AC-010, AC-014 | Story 1 |
+| 3 — End-to-end test coverage | [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) | NFR-005, AC-007, AC-011, AC-012, AC-013 | Stories 1 & 2 |
+
+**Not a story in this requirement** (per Stage 1, unchanged): any API exposure of the field, a
+lookup-by-reference endpoint, or a backfill job.

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/04-test-specs.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/04-test-specs.md
@@ -86,7 +86,7 @@ and `<task>_<behaviour>` for live tests (matching
 - **Reinforced by (integration):** `IngestionProcessByCaseHttpLiveTest.seedExistingCaseDocument(...)`
   (line ~136) performs exactly this kind of column-less raw insert and must keep working
   **unmodified** — the live proof that the column's nullability preserves backward compatibility
-  (NFR-004). Covered as Scenario 3.2.
+  (NFR-003). Covered as Scenario 3.2.
 
 **Scenario 1.3 — The entity mapping matches the column, and `TEXT` stores the value byte-for-byte**
 - **Given** the `CaseDocument` entity with its new `@Column(name = "rag_document_reference") private String ragDocumentReference`
@@ -302,7 +302,7 @@ returning a `CaseDocument` whose `ragDocumentReference` is **already set** to a 
 
 ## Story 3 — End-to-end test coverage for `rag_document_reference` (DD-43138)
 
-**Scenario 3.1 — The column is populated through the real ingestion flow, with the two-stub ordering hazard resolved** *(AC-011, NFR-005)*
+**Scenario 3.1 — The column is populated through the real ingestion flow, with the two-stub ordering hazard resolved** *(AC-011, NFR-004)*
 - **Given** the `gradle integration` compose stack (app + PostgreSQL + Artemis + Azurite +
   azurite-seed + WireMock), a `case_documents` row seeded directly via JDBC in phase
   `WAITING_FOR_UPLOAD` with `rag_document_reference IS NULL`, and a Task Manager `jobs` row seeded
@@ -361,7 +361,7 @@ returning a `CaseDocument` whose `ragDocumentReference` is **already set** to a 
   and adds a second asynchronous hop; if it proves flaky, drop it and rely on the unit coverage,
   recording the decision on the ticket rather than leaving a quarantined test behind.
 
-**Scenario 3.2 — No API or response-shape regression across the existing live suites** *(AC-007, NFR-004)*
+**Scenario 3.2 — No API or response-shape regression across the existing live suites** *(AC-007, NFR-003)*
 - **Given** the full set of existing `*HttpLiveTest` classes, **with their assertions unmodified**
 - **When** `gradle integration` runs after `V1013`, the entity field and the task change have all
   landed
@@ -370,7 +370,7 @@ returning a `CaseDocument` whose `ragDocumentReference` is **already set** to a 
     raw `INSERT INTO case_documents (doc_id, case_id, material_id, source, doc_name, blob_uri,
     uploaded_at, ingestion_phase, ingestion_phase_at, defendant_id, courtdoc_id, created_at)` omits
     the new column entirely and must keep working — which it does *only* because the column is
-    nullable with no default (NFR-004, and the practical consequence of ADR-002's "no `NOT NULL`").
+    nullable with no default (NFR-003, and the practical consequence of ADR-002's "no `NOT NULL`").
   - `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`, `DocumentHttpLiveTest`,
     `AnswersHttpLiveTest`, `QueriesHttpLiveTest`, `QueryVersionsHttpLiveTest`,
     `ActuatorHttpLiveTest` — no response body gains a field, because no controller, mapper or DTO

--- a/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/04-test-specs.md
+++ b/docs/pipeline/DD-43083-persist-doc-ingestion-transaction-id/04-test-specs.md
@@ -1,0 +1,511 @@
+# Test Specs: Persist the RAG Document-Ingestion Reference on `case_documents`
+
+> **Stage 4 — Test Specs** · Service: `cp-case-document-knowledge-service` (CDKS)
+> **Jira: DD-43083** · Stories: [`03-stories.md`](./03-stories.md) · Design: [`02-design.md`](./02-design.md) ·
+> Requirements: [`01-requirements.md`](./01-requirements.md) ·
+> ADRs: [`adrs/DD-43083-persist-doc-ingestion-transaction-id.md`](../adrs/DD-43083-persist-doc-ingestion-transaction-id.md)
+> (ADR-001 `rag_document_reference`, ADR-002 `TEXT` verbatim — both **Accepted**, not reopened here).
+>
+> **Written prospectively — no implementation exists yet.** Unlike the sibling
+> [`DD-43084/04-test-specs.md`](../DD-43084-persist-rag-transaction-id/04-test-specs.md), which was
+> written retrospectively against merged code and could name already-green tests as "Proof", every
+> scenario below states **"To be proven by:"** — a *plan* for a test to write, not a report of a
+> test that passed. Nothing in this document should be read as evidence of coverage. `V1013`, the
+> `CaseDocument.ragDocumentReference` field, and the `saveDocumentUploaded(...)` signature change
+> do not exist on this branch yet, so none of the named tests can compile until Stage 5 lands the
+> production change described in design §1–§4.
+>
+> **Test-authoring order is Story 1 → Story 2 → Story 3**, matching the story dependency chain
+> (`03-stories.md` §Summary). Within Story 2, unit tests can be written first (A-TDD, red) because
+> the seam — `ArgumentCaptor<CaseDocument>` on `CaseDocumentRepository.saveAndFlush(...)` — already
+> exists in `RetrieveMaterialAndUploadTaskTest` (line ~82); only the new getter/setter and the
+> fifth `saveDocumentUploaded(...)` parameter are missing.
+
+---
+
+## Test inventory — files to create or extend
+
+| Tier | File | New / extend | Story |
+|---|---|---|---|
+| Unit | `src/test/java/uk/gov/hmcts/cp/cdk/repo/CaseDocumentRepositoryTest.java` | extend | 1 |
+| Unit | `src/test/java/uk/gov/hmcts/cp/cdk/jobmanager/caseflow/RetrieveMaterialAndUploadTaskTest.java` | extend | 2 |
+| Unit | `src/test/java/uk/gov/hmcts/cp/cdk/jobmanager/caseflow/CheckIngestionStatusForAllDefendantsTaskTest.java` | extend | 2 |
+| Unit | `src/test/java/uk/gov/hmcts/cp/cdk/services/IdpcAvailabilityServiceTest.java` | extend | 2 |
+| Integration | `src/integrationTest/java/uk/gov/hmcts/cp/cdk/jobmanager/caseflow/RetrieveMaterialAndUploadRagDocumentReferenceLiveTest.java` | **new** | 3 |
+| Integration | `IngestionProcessByCaseHttpLiveTest`, `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`, `DocumentHttpLiveTest`, `AnswersHttpLiveTest` | **unmodified — run as regression** | 3 |
+
+No new WireMock static mapping file, no new `__files` fixture, no new `pactVerificationTest` class
+(no contract change — FR-009). The new IT registers its own stub programmatically (see Scenario 3.1)
+rather than adding a mapping to the shared `wiremock/mappings/` directory, precisely to avoid making
+the existing two-stub collision a three-stub collision.
+
+**Naming convention:** `should<Outcome>_when<Condition>` for unit tests (matching the existing
+`shouldSaveDocumentUploadedWhenCopyUrlSuccessful` / `shouldComplete_whenDocIdMissing` house style),
+and `<task>_<behaviour>` for live tests (matching
+`checkStatusTask_persistsRagTransactionId_forDefaultLevelAnswer`).
+
+---
+
+## Story 1 — Add `rag_document_reference` column to `case_documents` (DD-43136)
+
+**Scenario 1.1 — Migration is additive, metadata-only, and idempotent**
+- **Given** a database already migrated to `V1012` (the last shipped migration, added by DD-43084)
+- **When** Flyway applies
+  `V1013__add_rag_document_reference_to_case_documents.sql`
+- **Then** `case_documents` gains exactly one new nullable `TEXT` column named
+  `rag_document_reference`; no existing column, constraint (`cd_blob_uri_not_blank`,
+  `cd_source_not_blank`, `cd_size_nonneg`, `cd_sha256_shape`), index
+  (`idx_cd_case_uploaded_desc`, `idx_cd_case_phase`, `idx_cd_phase`), view
+  (`v_case_ingestion_status`), foreign key (`fk_cqs_doc`, `fk_cllda_doc`, `fk_def_doc`) or the
+  `document_ingestion_phase_enum` type is altered; no row is rewritten; and because the statement is
+  `ADD COLUMN IF NOT EXISTS`, re-running it is a no-op rather than an error.
+- **To be proven by:** the existing Testcontainers-backed Spring context tests, which run the whole
+  Flyway chain against a fresh `postgres:16-alpine` on every `gradle test` —
+  `CaseDocumentRepositoryTest`, `QueryVersionRepositoryTest`, `IngestionStatusViewRepositoryTest`,
+  `QueriesAsOfRepositoryTest`, `DiscoverySchedulerConfigurationRepositoryTest`,
+  `JobManagerConfigTest`. A malformed `V1013` fails context startup for all of them, so this is a
+  broad (if implicit) guard. **No new test file** — but the author must confirm the run is genuinely
+  green *after* adding `V1013`, not assume it.
+- **Additional deliberate check:** a **new** `CaseDocumentRepositoryTest.shouldRoundTripRagDocumentReference_whenSavedThroughTheEntity`
+  (see 1.3) is the first assertion that names the column explicitly rather than relying on
+  "the context booted".
+
+**Scenario 1.2 — Pre-existing rows and column-less inserts leave `NULL`, with no backfill**
+- **Given** `case_documents` rows written before `V1013` — including rows created by
+  `IdpcAvailabilityService.persistCaseDocument(...)` in phase `WAITING_FOR_UPLOAD`, and rows whose
+  upload never reached the `UPLOADED` transition
+- **When** `V1013` runs, and afterwards when a row is inserted by SQL that does not mention the new
+  column at all
+- **Then** `rag_document_reference IS NULL` for every such row; no error is raised; no backfill is
+  attempted; `IS NULL` is therefore the single unambiguous predicate for "no reference recorded"
+  (design §4).
+- **To be proven by:** `CaseDocumentRepositoryTest.shouldLeaveRagDocumentReferenceNull_whenRowInsertedWithoutTheColumn`
+  (new) — reuse the class's existing private `persist(...)` JDBC helper (line ~106), whose
+  `INSERT INTO case_documents (...)` column list deliberately stays unchanged, then assert
+  `SELECT rag_document_reference` returns `null` for that `doc_id`.
+- **Reinforced by (integration):** `IngestionProcessByCaseHttpLiveTest.seedExistingCaseDocument(...)`
+  (line ~136) performs exactly this kind of column-less raw insert and must keep working
+  **unmodified** — the live proof that the column's nullability preserves backward compatibility
+  (NFR-004). Covered as Scenario 3.2.
+
+**Scenario 1.3 — The entity mapping matches the column, and `TEXT` stores the value byte-for-byte**
+- **Given** the `CaseDocument` entity with its new `@Column(name = "rag_document_reference") private String ragDocumentReference`
+- **When** an entity carrying a value is saved via `repository.saveAndFlush(...)`, the persistence
+  context is cleared, and the row is re-read via `findById(...)`
+- **Then** the value returned is identical to the value written — no trim, no case-fold, no
+  canonicalisation (which is the concrete behavioural difference ADR-002 chose `TEXT` to get; a
+  Postgres `uuid` column would canonicalise mixed-case and brace/unhyphenated input, breaching
+  AC-001).
+- **To be proven by:** `CaseDocumentRepositoryTest.shouldRoundTripRagDocumentReference_whenSavedThroughTheEntity`
+  (new) — save with a mixed-case synthetic UUID-shaped string, `em.flush()` / `em.clear()`, re-read,
+  assert `isEqualTo` on the exact original string (not `equalToIgnoringCase`).
+- **Deliberate scope note:** this test does **not** prove `spring.jpa.hibernate.ddl-auto: validate`
+  accepts the mapping. `application-datasource.yml` (where `ddl-auto: validate` lives) is **not**
+  imported by `src/test/resources/application.yml`, so `@DataJpaTest` runs with Boot's default
+  `ddl-auto` for a non-embedded, Flyway-managed datasource — i.e. schema validation is not
+  exercised at the unit tier. The `validate` check is an integration-tier proof only (Scenario 3.3).
+  Do not claim AC-009 from `gradle test`.
+
+---
+
+## Story 2 — Persist and preserve the RAG `documentReference` (DD-43137)
+
+All scenarios in this story target
+`jobmanager/caseflow/RetrieveMaterialAndUploadTask` and
+`jobmanager/caseflow/CheckIngestionStatusForAllDefendantsTask` per design §4–§5.
+
+**Shared Given for 2.1–2.5** (the existing `RetrieveMaterialAndUploadTaskTest` fixture, unchanged):
+a `RETRIEVE_MATERIAL_AND_UPLOAD` `ExecutionInfo` whose job data carries `caseId`, `defendantId`,
+`materialId`, `docId`, `materialName`, `CJSCPPUID` and `requestId`; `progressionClient` returns a
+download URL; `storageService.copyFromUrl(...)` returns a `DocumentBlobMetadata`; and
+`caseDocumentRepository.findById(documentId)` returns a `CaseDocument`.
+
+---
+
+**Scenario 2.1 — The reference is persisted in the *same single* `saveAndFlush` as every other upload field** *(AC-001, AC-002, FR-002)*
+- **Given** `initiateDocumentUpload(...)` returns a `FileStorageLocationReturnedSuccessfully` whose
+  `documentReference` is a known synthetic UUID-shaped string
+- **When** the task executes successfully
+- **Then** `CaseDocumentRepository.saveAndFlush(...)` is invoked **exactly once**, and the captured
+  `CaseDocument` carries, in that one write: `ragDocumentReference` equal to the returned value
+  *verbatim*, plus `docName`, `blobUri`, `contentType`, `sizeBytes`, a non-null `uploadedAt`,
+  `ingestionPhase = UPLOADED` and a non-null `ingestionPhaseAt`. The task returns `COMPLETED`.
+- **To be proven by:** `RetrieveMaterialAndUploadTaskTest.shouldPersistRagDocumentReferenceInTheSameSaveAndFlush_whenUploadSucceeds`
+  (new; may instead be delivered as a strengthening of the existing
+  `shouldSaveDocumentUploadedWhenCopyUrlSuccessful`, which already captures the entity and asserts
+  `ingestionPhase`/`blobUri` — extending it is acceptable, but the **`times(1)`** assertion is the
+  part AC-002 actually demands and is currently absent). Use the class's existing
+  `@Captor ArgumentCaptor<CaseDocument> caseDocumentCaptor` (line ~82) with
+  `verify(caseDocumentRepository, times(1)).saveAndFlush(caseDocumentCaptor.capture())`.
+- **Note:** asserting `times(1)` is what pins FR-002's "no new write, no second transaction". A
+  future refactor that split the reference into its own `save` would still satisfy a bare `verify`,
+  so the explicit invocation count is load-bearing, not decorative.
+
+**Scenario 2.2 — A non-UUID-shaped reference is stored verbatim: neither discarded nor fatal** *(AC-014, ADR-002)*
+- **Given** `initiateDocumentUpload(...)` returns a deliberately non-UUID-shaped, non-blank
+  `documentReference` (e.g. `"not-a-uuid"`)
+- **When** the task executes
+- **Then** the captured `CaseDocument.ragDocumentReference` holds that exact string — not `null`,
+  not truncated, not case-folded, not parsed — **and** no exception escapes the persistence step:
+  the task still returns `COMPLETED` and still schedules
+  `CHECK_INGESTION_STATUS_FOR_ALL_DEFENDANTS` with the same value in job data. This is the "neither
+  (a) silently discarded nor (b) failing the ingestion flow" behaviour AC-014 requires an explicit
+  test for.
+- **To be proven by:** `RetrieveMaterialAndUploadTaskTest.shouldStoreRagDocumentReferenceVerbatim_whenReferenceIsNotUuidShaped`
+  (new — this is the single test AC-014 names, and it must be a dedicated, self-documenting case).
+- **Pre-existing corroboration worth recording:** the current fixtures already use non-UUID strings
+  — `shouldUploadDocumentAndScheduleNextTask` stubs `getDocumentReference()` as `"document-id"`,
+  and `shouldSaveDocumentUploadedWhenCopyUrlSuccessful` /
+  `shouldHandleNullBlobMetadata` / `shouldFallbackToCaseLevelSupersededDocs` construct
+  `new FileStorageLocationReturnedSuccessfully("storage-url", "doc-ref")`. Under a `UUID` column
+  those four fixtures would have had to change (or would have silently null-ed); under ADR-002's
+  `TEXT` they keep passing untouched. That is a useful incidental signal, but it is **not** a
+  substitute for the dedicated test — none of them asserts anything about the new field.
+
+**Scenario 2.3 — A `null` reference leaves the column `NULL` and does not change the task outcome** *(AC-004, FR-007)*
+- **Given** `initiateDocumentUpload(...)` returns a body whose `documentReference` is `null` (and a
+  non-null `storageUrl`, so the pre-existing line ~117 dereference still succeeds)
+- **When** the task executes
+- **Then** `saveAndFlush(...)` is still invoked once and the captured entity's `ragDocumentReference`
+  is `null` (via the null-safe `isBlank(...)` guard — the added line cannot throw); and the task's
+  **existing, unchanged** outcome follows: `JsonObjectBuilder.add(CTX_DOC_REFERENCE_KEY, null)`
+  throws `NullPointerException`, the method-level `catch (Exception ex)` converts it to
+  `ExecutionStatus.INPROGRESS` with `isShouldRetry() == true`, and no next task is scheduled.
+- **To be proven by:** `RetrieveMaterialAndUploadTaskTest.shouldLeaveRagDocumentReferenceNullAndRetry_whenReferenceIsNull`
+  (new) — assert the captured entity's field is `null`, assert `INPROGRESS` + `shouldRetry`, and
+  `verifyNoInteractions(executionService)` (or `verify(executionService, never()).executeWith(any())`).
+- **Explicitly asserting the pre-existing wart, not fixing it.** Design §6 records that the row is
+  saved as `UPLOADED` *before* the NPE, so the task retries over an already-`UPLOADED` row. That is
+  current behaviour and out of scope; the test pins it so a later well-meaning "fix" is a visible,
+  deliberate change rather than a silent one.
+
+**Scenario 2.4 — A blank (`""`) reference behaves identically to `null`** *(AC-004, design §4)*
+- **Given** `documentReference` is the empty string
+- **When** the task executes
+- **Then** the captured entity's `ragDocumentReference` is **`null`, not `""`** — the one and only
+  mapping the design applies, so that `IS NULL` remains the single "absent" representation and a
+  zero-length string never becomes a second, indistinguishable one. Task outcome as 2.3 (the
+  `add(..., "")` call itself does not throw, so confirm at implementation time whether the
+  observable outcome is `COMPLETED`-with-a-blank-job-data-value rather than a retry, and assert
+  whatever the *unchanged* pre-existing behaviour actually is — do not "improve" it in this ticket).
+- **To be proven by:** `RetrieveMaterialAndUploadTaskTest.shouldLeaveRagDocumentReferenceNull_whenReferenceIsBlank`
+  (new).
+- **Open point for the implementer:** 2.3 and 2.4 diverge in task outcome (`null` → NPE → retry;
+  `""` → no NPE). Design §6's table only spells out the `null` path. Assert the blank path's real
+  behaviour empirically and, if it differs from the `null` path, note it on the ticket rather than
+  forcing symmetry.
+
+**Scenario 2.5 — A retry of `RETRIEVE_MATERIAL_AND_UPLOAD` overwrites the previous reference (last-write-wins)** *(design §5, story DoD delta)*
+- **Given** a `CaseDocument` that already carries a `ragDocumentReference` from an earlier attempt
+  (stub `findById` to return an entity pre-populated with reference `A`)
+- **When** the task runs again and `initiateDocumentUpload(...)` returns a **different** reference
+  `B` — the real retry path, since a retry re-initiates the upload
+- **Then** the captured entity's `ragDocumentReference` is `B`, not `A`, and not both — no
+  write-once / `COALESCE`-style guard. This is **correct and intended**: the stored reference must
+  identify the ingestion transaction that produced the blob currently recorded in `blob_uri`, and
+  the retry has just replaced that blob. `CaseDocument` has no `@Version` field, so this is plain
+  last-write-wins, exactly as every other field on the row already behaves.
+- **To be proven by:** `RetrieveMaterialAndUploadTaskTest.shouldOverwriteRagDocumentReference_whenTaskRetriesWithANewReference`
+  (new).
+- **Why this scenario exists:** design §5 flags that FR-005's "written once, never overwritten"
+  holds for *phase transitions only*, and asks for the retry semantic to be "pinned rather than
+  incidental". Without this test, a future reviewer reading FR-005 could add a write-once guard in
+  good faith and leave rows pointing at abandoned ingestion transactions. The test is the guard
+  against the guard.
+
+---
+
+**Shared Given for 2.6–2.8** (the existing `CheckIngestionStatusForAllDefendantsTaskTest` fixture):
+job data carrying `docId`, `blobName`, `caseId`, `CTX_DOC_REFERENCE_KEY`, `CTX_LATEST_DEFENDANT`,
+`defendantId`; `documentIngestionStatusApi.documentStatusByReference(...)` stubbed with the relevant
+`DocumentIngestionStatus`; and — **the change from today** — `caseDocumentRepository.findById(docId)`
+returning a `CaseDocument` whose `ragDocumentReference` is **already set** to a known value
+(currently these tests return a bare `new CaseDocument()`).
+
+**Scenario 2.6 — The reference survives the transition to `INGESTED`** *(AC-003, FR-005)*
+- **Given** a persisted row whose `ragDocumentReference` is a known synthetic value, and a RAG status
+  poll returning `INGESTION_SUCCESS`
+- **When** `CheckIngestionStatusForAllDefendantsTask` transitions the phase
+- **Then** the saved entity has `ingestionPhase = INGESTED` **and** `ragDocumentReference` unchanged
+  — not nulled, not altered. `updateIngestionPhase(...)` mutates only the two phase fields on an
+  entity hydrated from the row, so this must hold with **zero production changes** in that task;
+  the test's job is to prove that claim rather than assume it.
+- **To be proven by:** `CheckIngestionStatusForAllDefendantsTaskTest.shouldPreserveRagDocumentReference_whenTransitioningToIngested`
+  (new) — extend/mirror the existing `shouldUpdateAndTriggerAllQueryTypes_whenIngestionSuccess_andLatestDefendant`,
+  which already asserts on the same `doc` instance via `verify(caseDocumentRepository).saveAndFlush(doc)`.
+
+**Scenario 2.7 — The reference survives the transition to `EXCEEDED_FILE_SIZE_LIMIT`** *(AC-003)*
+- **Given** as 2.6 but the poll returns `FILE_SIZE_OVER_LIMIT`
+- **When** the phase is transitioned
+- **Then** `ingestionPhase = EXCEEDED_FILE_SIZE_LIMIT` and `ragDocumentReference` is unchanged.
+- **To be proven by:** `CheckIngestionStatusForAllDefendantsTaskTest.shouldPreserveRagDocumentReference_whenTransitioningToExceededFileSizeLimit`
+  (new) — extend/mirror the existing
+  `shouldUpdateIngestionPhase_whenIngestionFailedDueToFileExceedingSizeLimit`.
+
+**Scenario 2.8 — The reference survives the transition to `FAILED`** *(AC-003)*
+- **Given** as 2.6 but the poll returns a failure status that maps to `DocumentIngestionPhase.FAILED`
+  (`INGESTION_FAILED` or `INVALID_METADATA` — confirm the exact mapping in the task before writing)
+- **When** the phase is transitioned
+- **Then** `ingestionPhase = FAILED` and `ragDocumentReference` is unchanged.
+- **To be proven by:** `CheckIngestionStatusForAllDefendantsTaskTest.shouldPreserveRagDocumentReference_whenTransitioningToFailed`
+  (new). **Note this is a genuinely new test case, not an extension** — the suite has no
+  `FAILED`-transition test today (it covers `INGESTION_SUCCESS`, `FILE_SIZE_OVER_LIMIT`, a missing
+  `docId`, and an API exception). AC-003 names all three phases, so all three need a case; this is
+  the one that adds coverage the suite currently lacks entirely.
+
+**Scenario 2.9 — Job-data threading to the status task is unchanged** *(FR-006)*
+- **Given** a successful `RETRIEVE_MATERIAL_AND_UPLOAD` execution
+- **When** the next task is scheduled
+- **Then** the scheduled `ExecutionInfo` for `CHECK_INGESTION_STATUS_FOR_ALL_DEFENDANTS` still
+  carries `CTX_DOC_REFERENCE_KEY` with **the same value** that was persisted to the row — persistence
+  is an added sink, not a replacement for the hand-off. (Design edit (3) substitutes the new local
+  for the inline `fileStorageLocation.getDocumentReference()` expression; this test is what proves
+  that substitution is behaviour-preserving.)
+- **To be proven by:** extending the existing
+  `RetrieveMaterialAndUploadTaskTest.shouldUploadDocumentAndScheduleNextTask` with an assertion that
+  `nextTask.getJobData().getString(CTX_DOC_REFERENCE_KEY)` equals both the stubbed value and the
+  captured entity's `ragDocumentReference` (the suite currently asserts only on `CTX_DOC_ID_KEY` and
+  the presence of `CTX_BLOB_NAME_KEY`).
+
+**Scenario 2.10 — A `WAITING_FOR_UPLOAD` row is created with the column `NULL`** *(AC-005)*
+- **Given** `IdpcAvailabilityService` discovering a new IDPC material for a case
+- **When** `persistCaseDocument(...)` creates the `CaseDocument` (setting `docId`, `caseId`,
+  `materialId`, `docName`, `blobUri`, `createdAt`, `ingestionPhase = WAITING_FOR_UPLOAD`,
+  `defendantId`, `courtdocId`)
+- **Then** the saved entity's `ragDocumentReference` is `null` — the field is simply left unset, with
+  no compile or behaviour change in that service, until upload initiation completes for the document.
+- **To be proven by:** `IdpcAvailabilityServiceTest.shouldLeaveRagDocumentReferenceNull_whenPersistingWaitingForUploadRow`
+  (new) — requires **new plumbing**: the class has no `ArgumentCaptor<CaseDocument>` today, so add
+  one and capture `caseDocumentRepository.saveAndFlush(...)` from one of the existing
+  new-document paths (e.g. the fixture behind `returnsNewDocuments_forMultipleDefendants`).
+- **Reinforced by:** Scenario 1.2 (the DB-level `IS NULL` on a column-less insert) and Scenario 3.1
+  (the live test seeds precisely such a `WAITING_FOR_UPLOAD` row and asserts the column is `NULL`
+  *before* the task runs).
+
+**Scenario 2.11 — Both touched unit suites remain green end to end** *(AC-010)*
+- **Given** the `saveDocumentUploaded(...)` signature gains a fifth parameter and `CaseDocument`
+  gains a field that joins the class-level `@EqualsAndHashCode` (design §3, "Known consequence")
+- **When** `gradle test` runs
+- **Then** `RetrieveMaterialAndUploadTaskTest` (9 existing tests) and
+  `CheckIngestionStatusForAllDefendantsTaskTest` (5 existing tests) compile and pass with their
+  existing assertions unmodified, as do `IdpcAvailabilityServiceTest`, `DocumentServiceTest` and
+  `CaseDocumentRepositoryTest`.
+- **To be proven by:** the full `gradle test` run — plus one specific manual check the author must
+  make rather than trust: design §3 asserts the new `equals`/`hashCode` member is *inert* because
+  nothing in `src/test/` or `src/integrationTest/` compares whole `CaseDocument` instances by
+  equality. Verify that (grep for `CaseDocument` in assertion positions, and note that
+  `CheckIngestionStatusForAllDefendantsTaskTest` uses `verify(...).saveAndFlush(doc)` — identity of
+  the same instance, so Mockito's `equals`-based argument matching is satisfied trivially). If any
+  suite does compare by value, that is a finding to raise, not to work around.
+
+---
+
+## Story 3 — End-to-end test coverage for `rag_document_reference` (DD-43138)
+
+**Scenario 3.1 — The column is populated through the real ingestion flow, with the two-stub ordering hazard resolved** *(AC-011, NFR-005)*
+- **Given** the `gradle integration` compose stack (app + PostgreSQL + Artemis + Azurite +
+  azurite-seed + WireMock), a `case_documents` row seeded directly via JDBC in phase
+  `WAITING_FOR_UPLOAD` with `rag_document_reference IS NULL`, and a Task Manager `jobs` row seeded
+  and addressed to `RETRIEVE_MATERIAL_AND_UPLOAD` with the job-data shape its predecessor produces
+  (`caseId`, `defendantId`, `materialId`, `docId`, `materialName`, `CJSCPPUID`, `requestId`)
+- **When** the live app's scheduled `JobExecutor` picks the job up and runs the **real** task against
+  the real database, the real Azurite blob copy (source `documents/source.pdf`, primed by
+  `azurite-seed` and returned by the existing `material_content_api` Progression stub) and the RAG
+  `POST /document-upload` stub
+- **Then** within the Awaitility window the row reaches `ingestion_phase = 'UPLOADED'` **and**
+  `rag_document_reference` equals the exact `documentReference` the stub served — read back via
+  JDBC, proving the value survives the full JPA write path and not just a mocked repository call.
+- **To be proven by:** `RetrieveMaterialAndUploadRagDocumentReferenceLiveTest.retrieveMaterialAndUploadTask_persistsRagDocumentReference_onCaseDocumentsRow`
+  (new), extending `AbstractHttpLiveTest` and mirroring
+  `CheckStatusOfAnswerGenerationRagTransactionIdLiveTest` beat for beat: `INSERT INTO jobs (...)`
+  seeding, `openConnection()`, `Awaitility.await().atMost(60s).pollInterval(2s)`, `finally` cleanup
+  of the `jobs` and `case_documents` rows it created.
+- **Resolution of the ordering hazard (design §Testing, "Stub caveat") — mitigation (a), sharpened.**
+  Two stubs answer `POST /document-upload` in the shared WireMock container: the static mapping
+  `wiremock/mappings/document_upload_to_generate_url.json` with a fixed
+  `documentReference` of `b181b0b0-628e-4491-9ccd-2ea93d70cb2f`, and the programmatic scenario stub
+  `DocumentIngestionInitiationApiStub.stubInitiateDocumentUpload(...)` registered by
+  `IngestionProcessHttpLiveTest` and `IngestionProcessByCaseHttpLiveTest`, which serves a fresh
+  `randomUUID()` and — once its scenario state settles on the final mapping — keeps matching. Later
+  registrations of equal priority win, so a hard-coded expectation of `b181b0b0-…` will flake on
+  suite ordering. The new IT must therefore register **its own** stub that is both
+  higher-priority *and* narrowly matched:
+  - `withPriority(1)` (lower number = higher precedence, so it beats both existing stubs, which are
+    at the default 5), **and**
+  - a body matcher on the unique document id this test generated —
+    `matchingJsonPath("$.documentId", equalTo(docId.toString()))` — so the new stub can only ever
+    answer *this* test's request and cannot shadow the other suites' `POST /document-upload` calls
+    in either direction. Priority alone would be sufficient for correctness but would make this test
+    the de-facto global handler for the whole `integration` run; the body matcher is what keeps the
+    blast radius at zero.
+  - the response must carry a **known fixed synthetic** `documentReference` (a hard-coded UUID-shaped
+    string declared as a constant in the test, so the assertion is exact equality, not
+    "non-null") **and** a genuinely valid `storageUrl` produced by the existing
+    `AzureSasUtil.generateSasUrl("documents-new", "<unique-blob-name>")` helper. Do **not** reuse
+    the static mapping's `storageUrl`: its SAS signature and `se=2026-04-09` expiry are baked into
+    the fixture, so the Azurite copy would fail and the row would never reach `UPLOADED`. Use a
+    per-run unique blob name so repeat runs and parallel suites do not collide.
+  - **Not chosen, and why:** asserting against WireMock's request/response journal (mitigation b)
+    couples the test to WireMock's admin API and reads back the value under test from the same
+    system that produced it; asserting only "non-null and equal to the job-data value"
+    (mitigation c) is the weakest of the three and would not catch a truncating or re-formatting
+    write, which is exactly what AC-001 cares about.
+- **Pre-condition assertion worth making explicit:** before seeding the job, assert the seeded row's
+  `rag_document_reference IS NULL`. That turns the test into a genuine before/after and rules out a
+  false pass from a leftover row (an `IS NULL` → value transition, not just "the value is there").
+- **Optional stretch (not required by any AC, decide at implementation):** because the real task
+  schedules `CHECK_INGESTION_STATUS_FOR_ALL_DEFENDANTS` and the existing `GET /document-upload/.*`
+  stub returns `INGESTION_SUCCESS`, the same test could go on to await
+  `ingestion_phase = 'INGESTED'` and re-assert `rag_document_reference` unchanged — an
+  integration-tier confirmation of Scenario 2.6. Attractive, but it lengthens the Awaitility window
+  and adds a second asynchronous hop; if it proves flaky, drop it and rely on the unit coverage,
+  recording the decision on the ticket rather than leaving a quarantined test behind.
+
+**Scenario 3.2 — No API or response-shape regression across the existing live suites** *(AC-007, NFR-004)*
+- **Given** the full set of existing `*HttpLiveTest` classes, **with their assertions unmodified**
+- **When** `gradle integration` runs after `V1013`, the entity field and the task change have all
+  landed
+- **Then** every one of them passes unchanged:
+  - `IngestionProcessByCaseHttpLiveTest` — the load-bearing one. Its `seedExistingCaseDocument(...)`
+    raw `INSERT INTO case_documents (doc_id, case_id, material_id, source, doc_name, blob_uri,
+    uploaded_at, ingestion_phase, ingestion_phase_at, defendant_id, courtdoc_id, created_at)` omits
+    the new column entirely and must keep working — which it does *only* because the column is
+    nullable with no default (NFR-004, and the practical consequence of ADR-002's "no `NOT NULL`").
+  - `IngestionProcessHttpLiveTest`, `IngestionStatusHttpLiveTest`, `DocumentHttpLiveTest`,
+    `AnswersHttpLiveTest`, `QueriesHttpLiveTest`, `QueryVersionsHttpLiveTest`,
+    `ActuatorHttpLiveTest` — no response body gains a field, because no controller, mapper or DTO
+    exposes any `CaseDocument` field (there is no `CaseDocumentMapper`).
+- **To be proven by:** the existing suites, run as a regression gate, **plus a diff-level check**
+  that is stronger than the runtime one: confirm from the PR diff that `src/main/.../controllers/`,
+  `services/DocumentService.java`, `services/IdpcAvailabilityService.java`, every mapper, every
+  OpenAPI model, `version.cdk`, `acl/cdks-rules.drl` and `resources/acl/*` are **untouched**, and
+  that `repo/CaseDocumentRepository.java` is unchanged. Runtime green-ness is a weak negative signal
+  here (most response assertions use `contains(...)`, so an added field would not necessarily fail
+  them) — the empty diff is the real evidence, exactly as DD-43084's Scenario 2.6 noted about its
+  own equivalent check. State both.
+
+**Scenario 3.3 — The app boots against a database migrated from `V1012` with pre-existing rows, proving `ddl-auto: validate` accepts the mapping** *(AC-006, AC-009, cross-checked with Story 1)*
+- **Given** a PostgreSQL 16 instance already at `V1012` containing `case_documents` rows written
+  before this change
+- **When** the compose stack starts and the app runs Flyway (`spring.flyway` locations
+  `classpath:db/migration/postgresql` and `classpath:db/migration`, `baseline-on-migrate: true`,
+  `out-of-order: true`) and then Hibernate schema validation with
+  `spring.jpa.hibernate.ddl-auto: validate`
+- **Then** `V1013` applies, the pre-existing rows show `rag_document_reference IS NULL`, Hibernate
+  accepts the `String` → `TEXT` mapping with no `columnDefinition` override or `@JdbcTypeCode`, and
+  the app reaches readiness — the live proof of the ADR-002 constraint that a `uuid` column would
+  have failed boot for a `String` field.
+- **To be proven by:** the `gradle integration` stack starting successfully (a
+  `SchemaManagementException` at boot fails every IT, so the signal is unmissable) plus
+  `ActuatorHttpLiveTest` reaching readiness. **This is the only tier at which `validate` is
+  exercised** — see the scope note on Scenario 1.3.
+- **Manual step the story DoD requires and CI does not give you for free:** the compose database is
+  normally fresh, so "fresh DB" and "already at `V1012` with rows" are *not* the same run. Do the
+  `V1012`-then-upgrade run deliberately once (start the stack on the pre-change commit, seed a few
+  synthetic `case_documents` rows, then restart on the change commit) and record the evidence on
+  DD-43136/DD-43138. Do not infer AC-009's second half from a green CI run.
+
+**Scenario 3.4 — Quality gates** *(AC-012)*
+- **Given** the complete change (migration + entity + task + tests)
+- **When** `gradle clean build` runs (which includes `integration`, since `check`/`build` depend on
+  it), followed by `gradle pmdMain pmdTest jacocoTestReport`, CodeQL and the secrets scanner
+- **Then** all pass at existing, **unmodified** thresholds, with no new PMD suppressions and no
+  lowered JaCoCo limits.
+- **To be proven by:** the CI workflows (`ci-build-publish`, `code-analysis`, `codeql`,
+  `secrets-scanner`) plus a local `gradle clean build`.
+- **Specific things to confirm rather than assume:** (a) the fifth `saveDocumentUploaded(...)`
+  parameter does not trip a PMD rule — design §4 establishes that `.github/pmd-ruleset.xml` enables
+  only `bestpractices`, `codestyle`, `errorprone`, `performance` and `security`, and that
+  `ExcessiveParameterList` lives in the *disabled* `design` category, so this should be a non-event;
+  if it nonetheless fires, the fix is a small local record (e.g. `UploadedBlob(blobName, blobUrl,
+  sizeBytes)`), **never** a suppression. (b) JaCoCo coverage on new lines: the change is ~4
+  production lines, all on paths the new unit tests exercise directly, so line coverage on new code
+  should comfortably clear the ≥80% standard — but the `null`/blank branches only count if
+  Scenarios 2.3 and 2.4 are actually written.
+
+**Scenario 3.5 — No PII, case data or real identifiers anywhere in the new test material** *(AC-013, CDKS hard rule)*
+- **Given** the new migration, the new/extended unit tests, and the new live test
+- **When** the diff is reviewed
+- **Then** every value is synthetic: `UUID.randomUUID()` or hard-coded synthetic UUID-shaped
+  constants for ids and references, no real court reference number, no real `CJSCPPUID`, no case
+  content, no document body, and no real material name. The `COMMENT ON COLUMN` text describes the
+  field's provenance and nullability only. The deliberately-malformed value used in Scenario 2.2
+  must be obviously synthetic (`"not-a-uuid"`), not a redacted real one.
+- **To be proven by:** the secrets scanner, the `block-pii` / `block-secrets` plugin hooks (which
+  run on every `Write`/`Edit`, so a violation is blocked at authoring time rather than caught at
+  review), and explicit reviewer sign-off at the Code Review stage.
+- **One pre-existing item to raise, not to change here:** the integration-test helper
+  `AzureSasUtil.generateSasUrl(...)` reads `AZURE_STORAGE_CONNECTION_STRING` from the environment.
+  The new IT should **reuse that helper as-is** — it is the established Azurite-emulator pattern in
+  this source set and is already used by `DocumentIngestionInitiationApiStub`. Do not introduce any
+  new connection-string handling, and do not extend this pattern beyond the existing call shape.
+  CDKS's Managed-Identity-only hard rule targets production Azure access; this test-side emulator
+  credential predates this ticket. Flag it to the reviewer for a separate decision rather than
+  widening or silently entrenching it.
+
+---
+
+## Coverage summary — **planned**, not achieved
+
+Every cell below describes coverage *to be written*. No row is evidence of a passing test.
+
+| AC | Scenario(s) | Unit (`src/test/`) | Integration (`src/integrationTest/`) | Planned test |
+|---|---|---|---|---|
+| AC-001 (stored verbatim, exactly as received) | 2.1, 2.2, 1.3 | planned | planned | `RetrieveMaterialAndUploadTaskTest.shouldPersistRagDocumentReferenceInTheSameSaveAndFlush_whenUploadSucceeds`; `CaseDocumentRepositoryTest.shouldRoundTripRagDocumentReference_whenSavedThroughTheEntity`; `RetrieveMaterialAndUploadRagDocumentReferenceLiveTest` |
+| AC-002 (single `saveAndFlush`, all fields together) | 2.1 | planned | — | as above, with `verify(..., times(1))` |
+| AC-003 (survives `INGESTED` / `FAILED` / `EXCEEDED_FILE_SIZE_LIMIT`) | 2.6, 2.7, 2.8 | planned (3 cases) | optional stretch only (3.1) | `CheckIngestionStatusForAllDefendantsTaskTest.shouldPreserveRagDocumentReference_whenTransitioningTo{Ingested,Failed,ExceededFileSizeLimit}` |
+| AC-004 (null / blank → `NULL`, outcome unchanged) | 2.3, 2.4 | planned (2 cases) | — | `...shouldLeaveRagDocumentReferenceNullAndRetry_whenReferenceIsNull`; `...shouldLeaveRagDocumentReferenceNull_whenReferenceIsBlank` |
+| AC-005 (`WAITING_FOR_UPLOAD` row is `NULL`) | 2.10, 1.2 | planned (new captor plumbing) | planned (3.1 pre-condition assertion) | `IdpcAvailabilityServiceTest.shouldLeaveRagDocumentReferenceNull_whenPersistingWaitingForUploadRow` |
+| AC-006 (pre-`V1013` rows are `NULL`, no backfill) | 1.2, 3.3 | planned | planned (manual `V1012`-upgrade run) | `CaseDocumentRepositoryTest.shouldLeaveRagDocumentReferenceNull_whenRowInsertedWithoutTheColumn` |
+| AC-007 (no API / DTO / mapper / `version.cdk` change) | 3.2 | — | planned (existing suites unmodified) + **diff-level check** | `IngestionProcessByCaseHttpLiveTest` et al., run as regression |
+| AC-008 (migration shape; `migration-reviewer`) | 1.1 | planned (implicit — Testcontainers migration chain) | planned (app boots) | existing repository/context tests + `migration-reviewer` review evidence on DD-43136 |
+| AC-009 (clean migrate: fresh **and** from `V1012` with rows) | 1.1, 3.3 | planned (fresh only) | planned (both — the `V1012` case needs a deliberate run) | compose-stack startup + `ActuatorHttpLiveTest` |
+| AC-010 (both touched unit suites green) | 2.11 | planned (`gradle test`) | — | full `gradle test`, plus the `@EqualsAndHashCode` inertness check |
+| AC-011 (populated end-to-end from a live stub) | 3.1 | — | planned (**the headline new test**) | `RetrieveMaterialAndUploadRagDocumentReferenceLiveTest.retrieveMaterialAndUploadTask_persistsRagDocumentReference_onCaseDocumentsRow` |
+| AC-012 (build / PMD / JaCoCo / CodeQL / secrets green) | 3.4 | planned | planned | `gradle clean build` + CI workflows |
+| AC-013 (no PII / case data / real identifiers) | 3.5 | planned | planned | secrets scanner, `block-pii` / `block-secrets` hooks, reviewer sign-off |
+| AC-014 (non-UUID value neither discarded nor fatal) | 2.2 | planned (**dedicated, AC-mandated**) | — | `...shouldStoreRagDocumentReferenceVerbatim_whenReferenceIsNotUuidShaped` |
+| design §5 (retry overwrite = last-write-wins) | 2.5 | planned | — | `...shouldOverwriteRagDocumentReference_whenTaskRetriesWithANewReference` |
+
+**Tier notes**
+- **Nothing is integration-only.** Every behavioural AC has a unit-tier plan, so a failure localises
+  to a class rather than to "the compose stack".
+- **AC-003 is deliberately unit-only** (with an optional integration stretch in 3.1). Driving three
+  distinct terminal phases through the live stack would need three seeded jobs and three status-stub
+  states for a behaviour whose mechanism — an entity hydrated from the row, with only two fields
+  mutated — is fully observable at the unit tier. Recorded as a conscious tier choice, not a gap.
+- **No contract tests.** No contract changes (FR-009); `pactVerificationTest` is untouched and the
+  consumed `api-cp-ai-rag` / `api-cp-crime-caseadmin-case-document-knowledge` artefact versions are
+  unchanged.
+- **No accessibility tests.** CDKS is backend-only with no UI; the WCAG 2.1 AA hard rule applies to
+  downstream consumers of CDKS's API, not to this change. No axe-core hooks, no E2E specs.
+
+---
+
+## Risks and open points carried into implementation
+
+1. **The WireMock two-stub hazard is the single biggest flake risk** (Scenario 3.1). Brief the
+   assigned developer before they write the IT. A test that hard-codes `b181b0b0-628e-4491-9ccd-2ea93d70cb2f`
+   will pass locally in isolation and fail in CI depending on whether an `IngestionProcess*HttpLiveTest`
+   ran first. The static mapping's baked-in, expired SAS `storageUrl` is a second, independent
+   reason not to depend on it.
+2. **Blank-vs-null task outcome asymmetry** (Scenario 2.4). Design §6's table documents only the
+   `null` path's NPE-then-retry. Assert the blank path's actual pre-existing behaviour; do not
+   normalise the two in this ticket.
+3. **`@EqualsAndHashCode` gains a member** (Scenario 2.11). Believed inert; verify rather than trust,
+   and do not add a one-field `@EqualsAndHashCode.Exclude` (design §3 rejects that as an
+   inconsistent special case, and the broader JPA-entity-equality smell is out of scope).
+4. **Story sequencing.** Story 3's IT cannot compile or pass until Stories 1 and 2 have merged. It
+   can be drafted in parallel, but do not open it as a standalone PR against `main`.
+5. **Upstream open questions still unresolved** and due before Stage 5 begins: **OQ-001** (the
+   literal DD-43083 ticket text was never fetched — no Jira access in these sessions; the whole
+   scope is a restatement) and **OQ-006** (whether the ticket's actual driver is for
+   `CheckIngestionStatusForAllDefendantsTask` to read the reference *from the row* instead of job
+   data, which would grow scope well beyond persistence). If either resolves differently, Story 2's
+   scenarios and this whole test plan need revisiting. **OQ-004** (external readers of
+   `case_documents`) and **OQ-007** (retention/purge) remain open for before-merge sign-off, and
+   **OQ-005** (index) stays deferred.
+6. **Jira sub-tickets are live.** Story 1 is [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136),
+   Story 2 is [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137), Story 3 is
+   [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) — CLAUDE.md's "linked Jira ticket per
+   story" precondition is satisfied; attach test evidence to these tickets.

--- a/docs/pipeline/adrs/DD-43083-persist-doc-ingestion-transaction-id.md
+++ b/docs/pipeline/adrs/DD-43083-persist-doc-ingestion-transaction-id.md
@@ -1,0 +1,206 @@
+# Architecture Decision Records — Persist the RAG Document-Ingestion Reference on `case_documents`
+
+> Service: `cp-case-document-knowledge-service` (CDKS) · Jira: DD-43083 · Taken at Stage 2 (Architecture & Design), resolving Stage 1 open questions OQ-002 and OQ-003.
+> Requirement: [`../DD-43083-persist-doc-ingestion-transaction-id/`](../DD-43083-persist-doc-ingestion-transaction-id/) ·
+> Requirements: [`01-requirements.md`](../DD-43083-persist-doc-ingestion-transaction-id/01-requirements.md) ·
+> Design: [`02-design.md`](../DD-43083-persist-doc-ingestion-transaction-id/02-design.md) ·
+> Sibling ADRs (answer side): [`DD-43084-persist-rag-transaction-id.md`](./DD-43084-persist-rag-transaction-id.md)
+>
+> Both ADRs below are **Accepted** — confirmed by the requester after design review with their
+> designers on 2026-08-11. `rag_document_reference TEXT NULL` is the locked column
+> name/type for `V1013` and is not reopened by later stages.
+
+---
+
+## ADR-001: Name the column `rag_document_reference`, not `doc_ingestion_tran_id`
+
+- **Status:** Accepted · **Date:** 2026-08-11 · **Jira:** DD-43083 · **Resolves:** OQ-002
+- **Artefacts:** `01-requirements.md` (FR-003, OQ-002) · `02-design.md` (§1–§3)
+
+### Context
+
+The input brief asks for "a similarly meaningful column name … something in the spirit of
+`doc_ingestion_tran_id`" — i.e. the requester's stated goal is a name consistent with what
+DD-43084 did, with `doc_ingestion_tran_id` offered as an illustration rather than a fixed token.
+Stage 1 recorded three candidates and left the choice to Design (OQ-002).
+
+Three facts constrain the answer:
+
+1. **The upstream contract does not call this a transaction id.** In `api-cp-ai-rag:0.0.15`
+   (`openapi/ai-rag-service.openapi.yml`) the field is `documentReference` on
+   `FileStorageLocationReturnedSuccessfully`, and the status path is
+   `GET /document-upload/{documentReference}`. CDKS's own job-data key already mirrors that
+   vocabulary: `JobManagerKeys.CTX_DOC_REFERENCE_KEY = "documentReference"`. "Transaction id" is
+   *our* interpretation of the field's role, not the contract's word for it — and whether the
+   reference is strictly per-upload or is a durable handle for the document inside RAG is not
+   something this repo can prove from the spec.
+2. **DD-43084 established a naming family, and it is the `rag_` prefix that carries the meaning.**
+   `V1012` added `rag_transaction_id` to four tables. The transferable part of that convention is
+   "prefix RAG-provenance correlation columns with `rag_` so they are greppable as a family and
+   never confused with CDKS's own identifiers" — not "call every RAG correlation id a transaction
+   id regardless of what RAG calls it".
+3. **This schema does not abbreviate.** Across `V1000`–`V1012` there is no `tran`, no `txn`, no
+   truncated word: `ingestion_phase_at`, `last_answer_version`, `scheduled_ingestion_request`,
+   `rag_transaction_id`, `court_centre_id`. PostgreSQL's identifier limit is 63 characters, so
+   abbreviation buys nothing here.
+
+### Decision
+
+Name the column **`rag_document_reference`**, mapped as `ragDocumentReference` on `CaseDocument`,
+with a `COMMENT ON COLUMN` that states both the source field and its role ("RAG-issued
+documentReference returned by `POST /document-upload` — the ingestion-transaction correlation id
+for this document (ingestion-side analogue of `answers.rag_transaction_id`)").
+
+Keep the *local variable and method parameter* in `RetrieveMaterialAndUploadTask` named
+`documentReference`, matching the RAG model and the existing `CTX_DOC_REFERENCE_KEY`; the `rag_`
+prefix exists to disambiguate provenance inside CDKS's schema, where a bare `document_reference`
+sitting next to `doc_id`, `doc_name` and `courtdoc_id` would read as one of CDKS's own identifiers.
+
+### Alternatives considered
+
+- **`doc_ingestion_tran_id`** (the brief's illustrative name) — rejected on three counts, any one
+  of which is minor but which compound: (a) `tran` is an abbreviation with no precedent anywhere in
+  this schema; (b) the `doc_` prefix collides conceptually with the existing `doc_id` / `doc_name`
+  family on the very same table, implying it belongs to CDKS's document identifiers when it is an
+  external system's value; (c) `_tran_id` asserts a semantic ("this is a transaction id") that the
+  RAG contract itself does not assert, so it is the one candidate that could become an outright
+  misnomer. Renaming a shipped column under an append-only Flyway policy is the most expensive
+  mistake available here, so the name that cannot go stale wins.
+- **`rag_ingestion_transaction_id`** — the strongest runner-up, and the right choice if reviewers
+  weight sibling symmetry with `rag_transaction_id` above fidelity to the source field. Rejected
+  as primary because it inherits exactly the risk in (c) above while being 10 characters longer
+  than the literal name, and because someone debugging with a RAG support ticket in hand is
+  searching for `documentReference`, not for a transaction id.
+- **`document_reference`** (no prefix) — rejected: loses the `rag_` provenance marker DD-43084
+  established, and reads as a CDKS-owned identifier alongside `doc_id`/`courtdoc_id`.
+- **Reusing the name `rag_transaction_id` on `case_documents`** — rejected: identical column names
+  holding values issued by two different RAG endpoints, with different semantics and lifetimes,
+  would make cross-table reasoning and any future data-export mapping actively misleading.
+
+### Consequences
+
+- **Positive:** the column name is a lossless pointer back to the exact upstream field, so
+  ingestion traceability is greppable in both directions (`documentReference` in RAG's logs and
+  contract, `rag_document_reference` in CDKS's schema). It stays correct whatever RAG later
+  clarifies about the reference's lifetime.
+- **Accepted:** the two RAG-provenance columns are not name-identical across tables
+  (`answers.rag_transaction_id` vs `case_documents.rag_document_reference`). They remain a
+  discoverable family via the shared `rag_` prefix, and each column comment cross-references the
+  other. This is the deliberate trade of visual symmetry for semantic accuracy.
+- **Accepted:** this recommendation diverges from the name in the input brief and therefore needs
+  an explicit accept/override at the Stage 2 gate before Story 1 (the migration) is written.
+- **Reversibility:** poor once shipped, which is precisely why it is being settled at Design.
+  Flyway is append-only, so a later rename means a new migration plus an entity change plus
+  coordination with any external reader of `case_documents` (OQ-004). Pick the name once.
+
+---
+
+## ADR-002: Store the reference as `TEXT`, verbatim — no UUID parse, no shape `CHECK`
+
+- **Status:** Accepted · **Date:** 2026-08-11 · **Jira:** DD-43083 · **Resolves:** OQ-003, satisfies AC-014
+- **Artefacts:** `01-requirements.md` (FR-003, FR-007, AC-001, AC-004, AC-014, OQ-003) · `02-design.md` (§1, §3, §4, §6)
+
+### Context
+
+Stage 1 left the SQL type genuinely open, with evidence both ways:
+
+**For `UUID`:** the RAG spec constrains `documentReference` via `allOf: [$ref '#/components/schemas/uuid']`,
+where `uuid` is a `string` with a UUID **regex pattern**; `GET /document-upload/{documentReference}`
+documents `400 — documentReference is not a valid uuid`; and DD-43084 stored the *same* `uuid`
+schema's `transactionId` as a `UUID` column.
+
+**For `TEXT`:** because the schema uses `pattern` rather than `format: uuid`, the generated Java
+type is `String` — `FileStorageLocationReturnedSuccessfully.getDocumentReference()`,
+`DocumentIngestionStatusApi.documentStatusByReference(String)` — and nothing in CDKS parses or
+validates it. Response bodies are not bean-validated on the client path, so the `@Pattern`
+annotation is decorative here; the value is threaded through job data as a string and handed
+straight back to RAG.
+
+Two further pieces of evidence, gathered at Design stage, decide it:
+
+1. **`spring.jpa.hibernate.ddl-auto: validate`** (`application-datasource.yml:22`). Hibernate
+   validates column types at startup, so a `String` entity field over a Postgres `uuid` column
+   fails boot. Choosing `UUID` is therefore not just a storage choice — it *forces* the entity
+   field, and hence the whole call path, to `java.util.UUID`, which forces a parse of a value the
+   application otherwise never parses.
+2. **The only parse helper in this repo is lossy by design.** `TaskUtils.parseUuidOrNull(...)`
+   logs a warning and returns `null` on a malformed value. Using it here would silently discard the
+   precise provenance data this ticket exists to preserve, in direct tension with CDKS's hard rule
+   "do not drop RAG response fields" (`.claude/context/cdks-context.md`).
+
+There is also a strong in-table precedent: every non-key string column on `case_documents` is
+`TEXT` — `source`, `doc_name`, `blob_uri`, `content_type`, and notably `sha256_hex`, a strictly
+shape-constrained hex string stored as `TEXT` with a `CHECK` rather than in a specialised type
+(`V1001__case_documents_ai_schema.sql`).
+
+### Decision
+
+Add **`rag_document_reference TEXT NULL`**, mapped to a `String` field, and store the value exactly
+as received from RAG.
+
+**Fallback behaviour, explicit and testable (AC-014):**
+
+| Input | Behaviour |
+|---|---|
+| Non-UUID-shaped, non-blank value | **Stored verbatim.** Not parsed, not rejected, not truncated, not null-ed, not case-folded. No exception. No `CHECK` constraint to violate. The same value continues to job data and to `documentStatusByReference(...)`, where RAG's own documented `400` is handled by the existing `CheckIngestionStatusForAllDefendantsTask` error path exactly as today. Optionally observable via existing INFO logging of the reference; **no new WARN is added**, because a malformed reference is an upstream contract breach that CDKS is recording, not diagnosing. |
+| `null` or blank | Column left `NULL`. The added persistence line cannot throw. Pre-existing behaviour then applies unchanged: `JsonObjectBuilder.add(CTX_DOC_REFERENCE_KEY, null)` throws NPE, the existing `catch` returns `INPROGRESS` + `shouldRetry`, and the row is left at `UPLOADED` with a `NULL` reference (FR-007, AC-004). |
+| Retry of `RETRIEVE_MATERIAL_AND_UPLOAD` | New reference **overwrites** the old one — last-write-wins, no write-once guard. The stored reference must identify the ingestion transaction that produced the blob currently in `blob_uri`. |
+
+Explicitly **no** `CHECK (rag_document_reference IS NULL OR rag_document_reference ~ '<uuid pattern>')`,
+by analogy with `cd_sha256_shape`: a failing CHECK raises on `saveAndFlush` and would turn a
+malformed-but-otherwise-successful upload into a task failure, breaching FR-007.
+
+This diverges from DD-43084's `UUID` column, and the divergence is principled rather than
+inconsistent: **both decisions store the value as the type the application actually holds.** On the
+answer side, `CheckStatusOfAnswerGenerationTask` had already parsed `transactionId` to a `UUID` for
+its own status-poll call, so a `UUID` column added no transformation. Here the in-memory type is
+`String` throughout, so `TEXT` adds no transformation. Persistence should not be the layer that
+introduces a parse.
+
+### Alternatives considered
+
+- **`UUID` column, parsing via `TaskUtils.parseUuidOrNull(...)`** — rejected: silently converts a
+  malformed reference to `NULL`, destroying the exact provenance the ticket exists to keep, and
+  makes "RAG never gave us one" and "RAG gave us something odd" indistinguishable in the data.
+  Directly at odds with CDKS's "do not drop RAG response fields" rule.
+- **`UUID` column, throwing on a malformed value** — rejected: promotes an upstream contract breach
+  into a failed ingestion and a retry loop over a value that will never parse, breaching FR-007
+  ("must not turn a previously-succeeding upload into a failure").
+- **`UUID` column plus a shadow `TEXT` column for unparseable values** (one of Stage 1's suggested
+  fallbacks) — rejected: two columns, two nullability states and a documented "check the other
+  column" rule, to model a single scalar. Strictly worse than one honest `TEXT` column.
+- **`UUID` column with normalisation-on-write** — rejected: Postgres canonicalises `uuid` input
+  (case-folding, accepting brace and unhyphenated forms), so the stored value can differ textually
+  from what RAG sent. That breaches AC-001's "preserved exactly as received … no case-folding, no
+  re-formatting" for any non-canonical input, and would make a byte-for-byte comparison against a
+  RAG-side log or support ticket unreliable.
+- **`TEXT` with a UUID-pattern `CHECK`** — rejected per the Decision: it is the CHECK-raises-on-save
+  problem in a different costume, and the shape contract belongs to RAG.
+- **`VARCHAR(36)`** — rejected: no advantage over `TEXT` in PostgreSQL (identical storage and
+  performance), the schema uses `TEXT` throughout, and a length cap would truncate or reject a
+  longer malformed value instead of recording it.
+
+### Consequences
+
+- **Positive:** the persisted value is byte-for-byte what RAG returned, so it can be pasted
+  straight into a RAG support query or matched against RAG-side logs with no normalisation caveat.
+  Zero new failure modes, zero new parse code, zero new helper, and no `MapSqlParameterSource`
+  plumbing (contrast DD-43084's seven-file change).
+- **Positive:** `String` → `TEXT` satisfies `ddl-auto: validate` with no `columnDefinition`
+  override or `@JdbcTypeCode`, matching the four existing `String` columns on this table. The
+  integration suite's successful app startup is itself the regression test for this.
+- **Accepted:** no database-level guarantee that the column contains a UUID. Consumers must treat
+  it as an opaque correlation string — which is exactly how every consumer, including RAG's own
+  status endpoint, treats it today. Anything requiring UUID semantics should validate at the point
+  of use, not rely on the column type.
+- **Accepted:** ~21 extra bytes per row versus a 16-byte `uuid`, on a table that already stores full
+  blob URIs as `TEXT`. Immaterial, and no index depends on it (FR-010).
+- **Accepted:** the two sibling columns have different SQL types (`answers.rag_transaction_id UUID`
+  vs `case_documents.rag_document_reference TEXT`). Any future join or export across them needs an
+  explicit cast. Judged cheaper than a lossy write path; the column comments record why.
+- **Reversible in the useful direction:** if UUID semantics are ever genuinely required,
+  `ALTER TABLE case_documents ALTER COLUMN rag_document_reference TYPE uuid USING rag_document_reference::uuid`
+  is a single additive migration — and it fails loudly if any malformed rows exist, which is
+  precisely the signal you would want before tightening the type. The reverse move (`uuid` → `TEXT`
+  after values have been silently null-ed by `parseUuidOrNull`) recovers nothing, because the
+  original strings were never stored. Choosing `TEXT` first is the one-way door avoided.


### PR DESCRIPTION
## Summary
- Adds the SDLC pipeline documentation (Requirements, Design, ADRs, User Stories, Test Specs) for DD-43083: persisting the RAG-issued document-ingestion reference (`documentReference`) onto `case_documents`, the ingestion-side sibling of DD-43084's `rag_transaction_id` work on the answer tables.
- Both design ADRs are **Accepted**: column named `rag_document_reference`, typed `TEXT` and stored verbatim (not `UUID`) — see `docs/pipeline/adrs/DD-43083-persist-doc-ingestion-transaction-id.md`.
- Sub-tickets are live: [DD-43136](https://tools.hmcts.net/jira/browse/DD-43136) (schema), [DD-43137](https://tools.hmcts.net/jira/browse/DD-43137) (persistence), [DD-43138](https://tools.hmcts.net/jira/browse/DD-43138) (test coverage).
- **Docs only — no production code, no migration, no tests written yet.** Implementation follows in a separate PR once these docs are reviewed.

## Test plan
- [ ] N/A — documentation-only change, no build/test impact
- [ ] Reviewer confirms ADR-001 (column name) and ADR-002 (column type/fallback behaviour) before implementation starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)