### PR TITLE
[DD-43063] structured logging

### DIFF
--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/03-stories.md
@@ -76,7 +76,7 @@ Reuses `DiscoveryService` unchanged via new `DiscoveryTriggerService` + dedicate
   clean build` incl. `integration` green, PMD/JaCoCo at existing thresholds (AC-024)
 
 ## Story 4 — Structured logging and correlation for manual discovery runs
-**Jira: DD-#####**
+**Jira: DD-43063**
 As an **on-call engineer**, I want **each manual trigger to emit one correlated start/completion
 log pair, explicitly distinguishable from a cron run**, so that **I can trace and audit manual
 interventions without confusing them with scheduled ones**.

--- a/docs/pipeline/DD-43036-manual-scheduler-trigger/04-test-specs.md
+++ b/docs/pipeline/DD-43036-manual-scheduler-trigger/04-test-specs.md
@@ -6,7 +6,7 @@
 > ADRs: [`adrs/DD-43036-manual-scheduler-trigger.md`](../adrs/DD-43036-manual-scheduler-trigger.md)
 >
 > Scenarios for `src/integrationTest/`, grouped by story. **Story 1 (DD-43060)** is contract-only
-> (no runtime behaviour here — no scenarios). **Story 4** not yet scoped into this file.
+> (no runtime behaviour here — no scenarios).
 
 ---
 
@@ -211,3 +211,80 @@ in `DiscoveryTriggerServiceTest`, since `DiscoveryService` already swallows per-
    catch-all, with unit coverage added to the existing `GlobalExceptionHandlerTest`. This is a
    deviation from design §2's "not changed" list for `GlobalExceptionHandler.java` — required for
    AC-002, not a scope choice.
+
+---
+
+## Story 4 — Structured logging and correlation for manual discovery runs (DD-43063)
+
+Covers **AC-018, AC-019, AC-020**. NFR-002 (Logging), NFR-007 (Observability).
+
+**Not independently deployable** — extends Story 3's `DiscoveryTriggerService`/`DiscoveryTriggerConfig`
+classes in place; no new endpoint or ACL surface.
+
+### What's new
+
+- `config/MdcCopyingTaskDecorator.java` (new) — captures `MDC.getCopyOfContextMap()` on the request
+  thread at submit time (before `RequestContextFilter`'s `finally` clears it), installs it on the
+  worker thread, runs the delegate, clears MDC in its own `finally`. Wired into
+  `discoveryTriggerExecutor` via `ThreadPoolTaskExecutor.setTaskDecorator(...)`.
+- `DiscoveryTriggerService.runWithLogging(...)` now puts `trigger=manual` and `discoveryOperation`
+  into MDC around the delegate call (cleared after) — promoted to top-level JSON fields by
+  `LogstashEncoder`, the explicit discriminator AC-019 requires (not timestamp inference).
+
+### Scenarios
+
+**S4.1 — MDC captured at submit time is visible on the worker thread (unit,
+`MdcCopyingTaskDecoratorTest`).** Given MDC has `correlationId` set on the calling thread, when
+`decorate(...)`'s returned `Runnable` runs on a *different* thread, then that value is visible
+inside it — even after the calling thread's MDC is cleared/mutated post-submit.
+
+**S4.2 — MDC is cleared after the decorated runnable completes (unit).** Given a pooled thread runs
+the decorated runnable, then that thread's MDC is empty afterward — proves no leakage into whatever
+task that pooled thread picks up next.
+
+**S4.3 — a null context map at decorate-time doesn't throw (unit).** Given no MDC is set when
+`decorate(...)` is called, then the returned `Runnable` still runs without error.
+
+**S4.4 — one correlated start/completion log pair per run, tagged `trigger=manual`, no PII
+(AC-018–020, unit, extends `DiscoveryTriggerServiceTest`).** Given `correlationId` is set on MDC and
+`trigger(...)` is invoked, when the captured `Runnable` is run (success and failure paths, each
+asserted separately), then a Logback `ListAppender` attached to `DiscoveryTriggerService`'s logger
+shows exactly one "starting" event and exactly one "finished"/"failed" event, both carrying
+`correlationId` + `trigger=manual` + `discoveryOperation` in their MDC property map, and no event's
+formatted message contains `CJSCPPUID`, a case/court identifier, or document content — trivially true
+by construction (the log statements only ever interpolate the enum), asserted here so a future
+edit can't silently add one.
+
+*Why unit-level, not IT:* asserting real log output from an IT would need a docker-log-scraping
+helper that doesn't exist in `testsupport/` today (flagged as an open question back in Story 2's
+spec); the `ListAppender` approach gives full, deterministic coverage of AC-018–020 without it.
+
+**S4.5 — non-blocking dispatch, delayed-stub proof (design §Testing item 5, IT, extends
+`DiscoverySchedulerTriggerHttpLiveTest`).** Given `/hearing-cases-for-day` is stubbed with a
+multi-second `fixedDelay` (`CP_CDK_HEARING_IS_HEARING_FOR_CASES_ENABLED=true` in the compose stack
+means `NIGHTLY` calls this endpoint directly and synchronously, once per date in the
+`nightly-discovery.days-ahead` window — no `scheduled_ingestion_request` seeding needed, unlike the
+`INTRADAY` path), when a System User triggers `NIGHTLY`, then the `202` returns in well under the
+stub's delay — proving the response is decoupled from the worker's total run time, not just from
+one call's latency as Story 3's S3.1 already showed with an un-stubbed instant response.
+
+### Coverage map
+
+| AC | Scenario(s) | Layer |
+|---|---|---|
+| AC-018 | S4.4 | Unit |
+| AC-019 | S4.4 | Unit |
+| AC-020 | S4.4 | Unit (+ manual review of the two log statements) |
+| (design item 5) | S4.5 | Integration |
+
+### Constraints and open questions
+
+1. **AC-018/019/020 are unit-level, not IT** — see S4.4's rationale above. The DoD's "manual +
+   automated check confirms no PII/case data in any log record" is satisfied by S4.4 (automated) plus
+   a one-time manual read of `DiscoveryTriggerService`'s two log statements (only `discoveryOperation`
+   is ever interpolated) — not a coded manual-test step.
+2. **S4.5 depends on the compose stack's `is-hearing-for-cases-enabled` toggle staying `true`.** If
+   that default ever flips, `NIGHTLY` falls back to the per-active-configuration/job-manager path
+   (indirect, async, harder to pin a delay to) and S4.5 would need reworking — flagging so a future
+   toggle change doesn't silently break this test for an unrelated reason.
+3. **Test data** — synthetic fixtures only; no case/court/user identifiers.

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerHttpLiveTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/http/DiscoverySchedulerTriggerHttpLiveTest.java
@@ -7,6 +7,7 @@ import static uk.gov.hmcts.cp.cdk.util.UtilConstants.USER_WITH_SYSTEM_USERS_GROU
 
 import uk.gov.hmcts.cp.cdk.testsupport.AbstractHttpLiveTest;
 import uk.gov.hmcts.cp.cdk.util.BrokerUtil;
+import uk.gov.hmcts.cp.cdk.stub.HearingQueryApiStub;
 import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
 
 import java.time.Duration;
@@ -149,5 +150,27 @@ class DiscoverySchedulerTriggerHttpLiveTest extends AbstractHttpLiveTest {
                     json.toString().contains("discovery-scheduler-trigger"));
             assertThat(auditMessage).as("expected an audit event for the trigger action").isNotNull();
         }
+    }
+
+    @Test
+    @DisplayName("NIGHTLY trigger returns 202 well before a delayed downstream call completes (design Testing item 5, Story 4)")
+    void trigger_nightly_returns202_beforeDelayedHearingCasesForDayCompletes() {
+        HearingQueryApiStub.stubGetHearingCasesForDayReturnsEmptyHearingCasesWithDelay(4000);
+
+        final String body = """
+                {
+                  "discoveryOperation": "NIGHTLY"
+                }
+                """;
+
+        final Instant before = Instant.now();
+        final ResponseEntity<String> response = http.exchange(
+                baseUrl + TRIGGER_PATH, HttpMethod.POST, new HttpEntity<>(body, vendorHeaders()), String.class);
+        final Duration elapsed = Duration.between(before, Instant.now());
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(elapsed)
+                .as("202 must return without waiting for the delayed hearing-cases-for-day call(s) to complete")
+                .isLessThan(Duration.ofSeconds(2));
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
@@ -15,12 +15,14 @@ public class HearingQueryApiStub {
     private static final String HEARINGS_PATH = "/hearing-query-api/query/api/rest/hearing/hearings";
     private static final String HEARING_CASES_FOR_DAY_PATH = "/hearing-query-api/query/api/rest/hearing/hearing-cases-for-day";
     public static final String APPLICATION_JSON = "application/json";
+    private static final String DATE = "date";
+    private static final String CONTENT_TYPE = "Content-Type";
 
     public static void stubGetHearingsReturnsEmptyHearingSummaries(final String courtCentreId, final String roomId) {
         stubFor(get(urlPathEqualTo(HEARINGS_PATH))
                 .withQueryParam("courtCentreId", equalTo(courtCentreId))
                 .withQueryParam("roomId", equalTo(roomId))
-                .withQueryParam("date", matching(".*"))
+                .withQueryParam(DATE, matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
                         .withHeader("Content-Type", APPLICATION_JSON)
@@ -33,7 +35,18 @@ public class HearingQueryApiStub {
                 .withQueryParam("date", matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
+                        .withBody("{\"hearingCases\":[]}")
+                ));
+    }
+
+    public static void stubGetHearingCasesForDayReturnsEmptyHearingCasesWithDelay(final int fixedDelayMs) {
+        stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
+                .withQueryParam("date", matching(".*"))
+                .willReturn(aResponse()
+                        .withStatus(SC_OK)
                         .withHeader("Content-Type", APPLICATION_JSON)
+                        .withFixedDelay(fixedDelayMs)
                         .withBody("{\"hearingCases\":[]}")
                 ));
     }

--- a/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
+++ b/src/integrationTest/java/uk/gov/hmcts/cp/cdk/stub/HearingQueryApiStub.java
@@ -25,14 +25,14 @@ public class HearingQueryApiStub {
                 .withQueryParam(DATE, matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
-                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody("{\"hearingSummaries\":[]}")
                 ));
     }
 
     public static void stubGetHearingCasesForDayReturnsEmptyHearingCases() {
         stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
-                .withQueryParam("date", matching(".*"))
+                .withQueryParam(DATE, matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
                         .withHeader(CONTENT_TYPE, APPLICATION_JSON)
@@ -42,10 +42,10 @@ public class HearingQueryApiStub {
 
     public static void stubGetHearingCasesForDayReturnsEmptyHearingCasesWithDelay(final int fixedDelayMs) {
         stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
-                .withQueryParam("date", matching(".*"))
+                .withQueryParam(DATE, matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
-                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withFixedDelay(fixedDelayMs)
                         .withBody("{\"hearingCases\":[]}")
                 ));
@@ -54,10 +54,10 @@ public class HearingQueryApiStub {
     public static void stubGetHearingCasesForDayReturnsHearingCase(final String courtCentreId, final String courtRoomId,
                                                                     final String caseId) {
         stubFor(get(urlPathEqualTo(HEARING_CASES_FOR_DAY_PATH))
-                .withQueryParam("date", matching(".*"))
+                .withQueryParam(DATE, matching(".*"))
                 .willReturn(aResponse()
                         .withStatus(SC_OK)
-                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withHeader(CONTENT_TYPE, APPLICATION_JSON)
                         .withBody("""
                                 {"hearingCases":[{
                                   "courtCentreId":"%s",

--- a/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerConfig.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/config/DiscoveryTriggerConfig.java
@@ -15,7 +15,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class DiscoveryTriggerConfig {
 
     @Bean("discoveryTriggerExecutor")
-    public ThreadPoolTaskExecutor discoveryTriggerExecutor(final DiscoveryTriggerProperties properties) {
+    public ThreadPoolTaskExecutor discoveryTriggerExecutor(final DiscoveryTriggerProperties properties,
+                                                            final MdcCopyingTaskDecorator taskDecorator) {
         final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);
         executor.setMaxPoolSize(1);
@@ -23,6 +24,7 @@ public class DiscoveryTriggerConfig {
         executor.setThreadNamePrefix("discovery-trigger-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(properties.getAwaitTerminationSeconds());
+        executor.setTaskDecorator(taskDecorator);
         executor.initialize();
         return executor;
     }

--- a/src/main/java/uk/gov/hmcts/cp/cdk/config/MdcCopyingTaskDecorator.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/config/MdcCopyingTaskDecorator.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.cp.cdk.config;
+
+import java.util.Map;
+
+import org.slf4j.MDC;
+import org.springframework.core.task.TaskDecorator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Captures MDC on the submitting (request) thread at decorate-time -- before
+ * RequestContextFilter's finally block clears it -- and re-installs it on the worker
+ * thread, so a manual discovery run's start/finish log lines still carry the request's
+ * correlationId (Story 4, DD-43063).
+ */
+@Component
+public class MdcCopyingTaskDecorator implements TaskDecorator {
+
+    @Override
+    public Runnable decorate(final Runnable runnable) {
+        final Map<String, String> contextMap = MDC.getCopyOfContextMap();
+        return () -> {
+            if (contextMap != null) {
+                MDC.setContextMap(contextMap);
+            }
+            try {
+                runnable.run();
+            } finally {
+                MDC.clear();
+            }
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.cp.cdk.services;
 import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
 
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
  * A separate class rather than a new DiscoveryService method: DiscoveryService's constructor
  * already takes 9 dependencies, so adding a TaskExecutor there would touch every
  * DiscoveryServiceTest construction site.
+ * trigger/discoveryOperation MDC tagging (Story 4, DD-43063) relies on MdcCopyingTaskDecorator
+ * having already copied the request's correlationId onto this worker thread's MDC.
  */
 @Slf4j
 @Service
@@ -38,14 +41,19 @@ public class DiscoveryTriggerService {
 
     private void runWithLogging(final DiscoveryOperation operation, final Runnable delegate) {
         final long startedAt = System.currentTimeMillis();
-        log.info("Manual discovery run starting discoveryOperation={} trigger=manual", operation);
+        MDC.put("trigger", "manual");
+        MDC.put("discoveryOperation", operation.toString());
         try {
+            log.info("Manual discovery run starting discoveryOperation={} trigger=manual", operation);
             delegate.run();
             log.info("Manual discovery run finished discoveryOperation={} trigger=manual durationMs={}",
                     operation, System.currentTimeMillis() - startedAt);
         } catch (final Exception e) {
             log.error("Manual discovery run failed discoveryOperation={} trigger=manual durationMs={}",
                     operation, System.currentTimeMillis() - startedAt, e);
+        } finally {
+            MDC.remove("trigger");
+            MDC.remove("discoveryOperation");
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/cp/cdk/config/MdcCopyingTaskDecoratorTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/config/MdcCopyingTaskDecoratorTest.java
@@ -1,0 +1,70 @@
+package uk.gov.hmcts.cp.cdk.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+@DisplayName("MdcCopyingTaskDecorator tests (Story 4, DD-43063)")
+class MdcCopyingTaskDecoratorTest {
+
+    private final MdcCopyingTaskDecorator decorator = new MdcCopyingTaskDecorator();
+
+    @AfterEach
+    void clearMdc() {
+        MDC.clear();
+    }
+
+    @Test
+    @DisplayName("MDC captured at decorate-time is visible inside the decorated runnable, on another thread")
+    void decorate_capturesMdcAtSubmitTime_visibleOnWorkerThread() throws InterruptedException {
+        MDC.put("correlationId", "abc-123");
+
+        final AtomicReference<String> seenOnWorker = new AtomicReference<>();
+        final Runnable decorated = decorator.decorate(() -> seenOnWorker.set(MDC.get("correlationId")));
+
+        MDC.remove("correlationId");
+
+        final Thread worker = new Thread(decorated);
+        worker.start();
+        worker.join();
+
+        assertThat(seenOnWorker.get()).isEqualTo("abc-123");
+    }
+
+    @Test
+    @DisplayName("MDC is cleared after the decorated runnable completes, so a pooled thread doesn't leak context")
+    void decorate_clearsMdcAfterRun_noLeakageBetweenPooledTasks() throws InterruptedException {
+        MDC.put("correlationId", "run-1");
+        final Runnable decorated = decorator.decorate(() -> { });
+
+        final AtomicReference<Map<String, String>> afterRun = new AtomicReference<>();
+        final Thread worker = new Thread(() -> {
+            decorated.run();
+            afterRun.set(MDC.getCopyOfContextMap());
+        });
+        worker.start();
+        worker.join();
+
+        assertThat(afterRun.get()).isNullOrEmpty();
+    }
+
+    @Test
+    @DisplayName("a null context map at decorate-time (no MDC set) is handled without throwing")
+    void decorate_nullContextMap_isHandled() throws InterruptedException {
+        MDC.clear();
+        final Runnable decorated = decorator.decorate(() -> { });
+
+        final Thread worker = new Thread(decorated);
+        assertThatCode(() -> {
+            worker.start();
+            worker.join();
+        }).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/cp/cdk/services/DiscoveryTriggerServiceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.cp.cdk.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -9,12 +10,19 @@ import static org.mockito.Mockito.verify;
 
 import uk.gov.hmcts.cp.openapi.model.cdk.DiscoveryOperation;
 
+import java.util.List;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.core.task.TaskExecutor;
 
-@DisplayName("DiscoveryTriggerService tests (Story 3, DD-43062)")
+@DisplayName("DiscoveryTriggerService tests (Story 3, DD-43062; logging tests Story 4, DD-43063)")
 class DiscoveryTriggerServiceTest {
 
     private final DiscoveryService discoveryService = mock(DiscoveryService.class);
@@ -60,5 +68,90 @@ class DiscoveryTriggerServiceTest {
         verify(discoveryTriggerExecutor).execute(captor.capture());
 
         assertThatCode(() -> captor.getValue().run()).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("worker run logs one correlated start + finished pair, tagged trigger=manual, no PII (AC-018-020)")
+    void trigger_emitsSingleCorrelatedStartFinishedLogPair_onSuccess() {
+        final Logger logger = (Logger) LoggerFactory.getLogger(DiscoveryTriggerService.class);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            MDC.put("correlationId", "corr-xyz");
+            service.trigger(DiscoveryOperation.NIGHTLY);
+            final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+            verify(discoveryTriggerExecutor).execute(captor.capture());
+            captor.getValue().run();
+        } finally {
+            logger.detachAppender(appender);
+            MDC.clear();
+        }
+
+        final List<ILoggingEvent> events = appender.list;
+        final List<ILoggingEvent> startEvents = events.stream()
+                .filter(e -> e.getFormattedMessage().contains("starting")).toList();
+        final List<ILoggingEvent> completionEvents = events.stream()
+                .filter(e -> e.getFormattedMessage().contains("finished")).toList();
+
+        assertThat(startEvents).hasSize(1);
+        assertThat(completionEvents).hasSize(1);
+        for (final ILoggingEvent event : events) {
+            assertThat(event.getMDCPropertyMap())
+                    .containsEntry("correlationId", "corr-xyz")
+                    .containsEntry("trigger", "manual")
+                    .containsKey("discoveryOperation");
+            assertThat(event.getFormattedMessage())
+                    .doesNotContainIgnoringCase("cjscppuid")
+                    .doesNotContainIgnoringCase("courtCentre")
+                    .doesNotContainIgnoringCase("caseId");
+        }
+    }
+
+    @Test
+    @DisplayName("worker run logs one correlated start + failed pair on error, MDC discriminators present (AC-018-020)")
+    void trigger_emitsSingleCorrelatedStartFailedLogPair_onException() {
+        doThrow(new RuntimeException("boom")).when(discoveryService).runIntradayDiscovery();
+
+        final Logger logger = (Logger) LoggerFactory.getLogger(DiscoveryTriggerService.class);
+        final ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+
+        try {
+            MDC.put("correlationId", "corr-fail");
+            service.trigger(DiscoveryOperation.INTRADAY);
+            final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+            verify(discoveryTriggerExecutor).execute(captor.capture());
+            captor.getValue().run();
+        } finally {
+            logger.detachAppender(appender);
+            MDC.clear();
+        }
+
+        final List<ILoggingEvent> events = appender.list;
+        final List<ILoggingEvent> startEvents = events.stream()
+                .filter(e -> e.getFormattedMessage().contains("starting")).toList();
+        final List<ILoggingEvent> failedEvents = events.stream()
+                .filter(e -> e.getFormattedMessage().contains("failed")).toList();
+
+        assertThat(startEvents).hasSize(1);
+        assertThat(failedEvents).hasSize(1);
+        for (final ILoggingEvent event : events) {
+            assertThat(event.getMDCPropertyMap()).containsEntry("trigger", "manual").containsKey("discoveryOperation");
+        }
+    }
+
+    @Test
+    @DisplayName("MDC discriminator fields (trigger, discoveryOperation) are cleared after the run completes")
+    void trigger_clearsMdcDiscriminatorFields_afterRun() {
+        service.trigger(DiscoveryOperation.INTRADAY);
+        final ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+        verify(discoveryTriggerExecutor).execute(captor.capture());
+        captor.getValue().run();
+
+        assertThat(MDC.get("trigger")).isNull();
+        assertThat(MDC.get("discoveryOperation")).isNull();
     }
 }


### PR DESCRIPTION
  What

  Adds the manual discovery scheduler trigger: POST /discovery-scheduler/trigger, restricted to System Users, fire-and-forget dispatch of INTRADAY/NIGHTLY, with correlated structured logging (DD-43061,
  DD-43062, DD-43063).

  Why
  
  Ops/support need to force a missed or extra discovery run on demand, without waiting for its cron or blocking on completion, and be able to trace a manual run in logs without confusing it with a scheduled
  one.

  Changes
  
  - ACL (DD-43061): new Drools rule, System-Users-group-only, no hasPermission fallback — acl/cdks-rules.drl; reviewed by rbac-auditor.
  - Trigger endpoint (DD-43062): DiscoveryTriggerService routes the operation to the existing, unchanged DiscoveryService methods via a dedicated bounded executor;
  DiscoverySchedulerController.triggerDiscovery(...) returns 202 with the vendor content type, echoing discoveryOperation/message/correlationId.
  - Structured logging (DD-43063): new MdcCopyingTaskDecorator propagates the request's correlationId onto the async worker thread; worker logs now carry trigger=manual + discoveryOperation in MDC, promoted to
  JSON fields by LogstashEncoder.
  - Bug fix: GlobalExceptionHandler was returning 500 instead of 405 for wrong-method requests on any endpoint (its catch-all handler pre-empted Spring's built-in 405 handling) — fixed with an explicit
  HttpRequestMethodNotSupportedException handler.
  - Tests: CdksAclRulesTest, DiscoverySchedulerTriggerAclHttpLiveTest, DiscoverySchedulerTriggerHttpLiveTest, DiscoveryTriggerServiceTest, MdcCopyingTaskDecoratorTest, plus extensions to
  DiscoverySchedulerControllerTest and GlobalExceptionHandlerTest.
  - New config: cdk.discovery-trigger.queue-capacity / await-termination-seconds.

